### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Suggests:
     epiparameter,
     distributional,
     fitdistrplus,
-    covr,
     knitr,
     bookdown,
     rmarkdown,


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.