### PR TITLE
Update {superspreading} to use new {epiparameter} feature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,6 @@ Imports:
     bpmodels
 Suggests: 
     epiparameter,
-    distributional,
     fitdistrplus,
     knitr,
     bookdown,

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -34,7 +34,6 @@ infectors infect few or zero individuals (@lloyd-smithSuperspreadingEffectIndivi
 ```{r setup}
 library(superspreading)
 library(epiparameter)
-library(distributional)
 ```
 
 ## Probability of epidemic
@@ -112,9 +111,9 @@ evd <- epidist_db(
 The parameters of each distribution can be extracted:
 
 ```{r, params}
-sars_params <- parameters(sars)
+sars_params <- get_parameters(sars)
 sars_params
-evd_params <- parameters(evd)
+evd_params <- get_parameters(evd)
 evd_params
 ```
 


### PR DESCRIPTION
This PR updates the DESCRIPTION and get started vignette to use the `get_parameters()` function instead of the removed `parameters()` function from {epiparameter}. This allows the removal of {distributional} as a suggested packages as the `parameters()` generic is no longer required.