### PR TITLE
Miscellaneous updates from full package review

### DIFF
--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -24,7 +24,7 @@
 #'
 #' @examples
 #' probability_contain(R = 1.5, k = 0.5, c = 1)
-probability_contain <- function(R, k, a = 1, c, # nolint
+probability_contain <- function(R, k, a = 1, c,
                                 control_type = c("population", "individual"),
                                 stochastic = TRUE,
                                 ...,
@@ -39,7 +39,7 @@ probability_contain <- function(R, k, a = 1, c, # nolint
 
   control_type <- match.arg(control_type)
   if (control_type == "population") {
-    R <- (1 - c) * R # nolint
+    R <- (1 - c) * R
   } else {
     stop("individual-level controls not yet implemented", call. = FALSE)
   }

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -20,7 +20,7 @@
 #'
 #' Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)
 #' Superspreading and the effect of individual variation on disease emergence.
-#' Nature, 438(7066), 355-359. <https://doi.org/10.1038/nature04153>
+#' Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 #'
 #' @examples
 #' probability_contain(R = 1.5, k = 0.5, c = 1)

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -24,7 +24,7 @@
 #'
 #' @examples
 #' probability_epidemic(R = 1.5, k = 0.1, a = 10)
-probability_epidemic <- function(R, k, a) { # nolint
+probability_epidemic <- function(R, k, a) {
   # check inputs
   checkmate::assert_number(R, lower = 0, finite = TRUE)
   checkmate::assert_number(k, lower = 0)
@@ -74,7 +74,7 @@ probability_epidemic <- function(R, k, a) { # nolint
 #'
 #' @examples
 #' probability_extinct(R = 1.5, k = 0.1, a = 10)
-probability_extinct <- function(R, k, a) { # nolint
+probability_extinct <- function(R, k, a) {
   # input checking done in probability_epidemic
   1 - probability_epidemic(R = R, k = k, a = a)
 }

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -20,7 +20,7 @@
 #' Kucharski, A. J., Russell, T. W., Diamond, C., Liu, Y., Edmunds, J.,
 #' Funk, S. & Eggo, R. M. (2020). Early dynamics of transmission and control
 #' of COVID-19: a mathematical modelling study. The Lancet Infectious Diseases,
-#' 20(5), 553-558. <https://doi.org/10.1016/S1473-3099(20)30144-4>
+#' 20(5), 553-558. \doi{10.1016/S1473-3099(20)30144-4}
 #'
 #' @examples
 #' probability_epidemic(R = 1.5, k = 0.1, a = 10)
@@ -70,7 +70,7 @@ probability_epidemic <- function(R, k, a) {
 #'
 #' Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005).
 #' Superspreading and the effect of individual variation on disease emergence.
-#' Nature, 438(7066), 355-359. <https://doi.org/10.1038/nature04153>
+#' Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 #'
 #' @examples
 #' probability_extinct(R = 1.5, k = 0.1, a = 10)

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -36,7 +36,7 @@
 #' # example with a vector of cluster sizes
 #' cluster_size <- c(5, 10, 25)
 #' proportion_cluster_size(R = R, k = k, cluster_size = cluster_size)
-proportion_cluster_size <- function(R, k, cluster_size) { # nolint
+proportion_cluster_size <- function(R, k, cluster_size) {
 
   # check input
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -61,7 +61,7 @@
 #'   k = k,
 #'   percent_transmission = percent_transmission
 #' )
-proportion_transmission <- function(R, k, percent_transmission, sim = FALSE) { # nolint
+proportion_transmission <- function(R, k, percent_transmission, sim = FALSE) {
 
   # check input
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
@@ -74,13 +74,13 @@ proportion_transmission <- function(R, k, percent_transmission, sim = FALSE) { #
 
   for (i in seq_len(nrow(df))) {
     if (sim) {
-      prop <- .proportion_transmission_numerical(
+      prop <- .prop_transmission_numerical(
         R = df[i, "R"],
         k = df[i, "k"],
         percent_transmission = percent_transmission
       )
     } else {
-      prop <- .proportion_transmission_analytical(
+      prop <- .prop_transmission_analytical(
         R = df[i, "R"],
         k = df[i, "k"],
         percent_transmission = percent_transmission
@@ -99,7 +99,7 @@ proportion_transmission <- function(R, k, percent_transmission, sim = FALSE) { #
 #' @return A numeric
 #' @keywords internal
 #' @noRd
-.proportion_transmission_analytical <- function(R, k, percent_transmission) { # nolint
+.prop_transmission_analytical <- function(R, k, percent_transmission) {
 
   xm1 <- stats::qnbinom(1 - percent_transmission, k + 1, mu = R * (k + 1) / k)
   remq <- 1 - percent_transmission -
@@ -117,7 +117,7 @@ proportion_transmission <- function(R, k, percent_transmission, sim = FALSE) { #
 #' @return A numeric
 #' @keywords internal
 #' @noRd
-.proportion_transmission_numerical <- function(R, k, percent_transmission) { # nolint
+.prop_transmission_numerical <- function(R, k, percent_transmission) {
 
   nsim <- 1e5
   simulate_secondary <- stats::rnbinom(

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -33,7 +33,7 @@
 #' Endo, A., Abbott, S., Kucharski, A. J., & Funk, S. (2020)
 #' Estimating the overdispersion in COVID-19 transmission using outbreak
 #' sizes outside China. Wellcome Open Research, 5.
-#' <doi.org/10.12688/wellcomeopenres.15842.3>
+#' \doi{10.12688/wellcomeopenres.15842.3}
 #'
 #' @examples
 #' # example of single values of R and k

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -50,5 +50,5 @@ probability_contain(R = 1.5, k = 0.5, c = 1)
 \references{
 Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)
 Superspreading and the effect of individual variation on disease emergence.
-Nature, 438(7066), 355-359. \url{https://doi.org/10.1038/nature04153}
+Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 }

--- a/man/probability_epidemic.Rd
+++ b/man/probability_epidemic.Rd
@@ -31,7 +31,7 @@ probability_epidemic(R = 1.5, k = 0.1, a = 10)
 Kucharski, A. J., Russell, T. W., Diamond, C., Liu, Y., Edmunds, J.,
 Funk, S. & Eggo, R. M. (2020). Early dynamics of transmission and control
 of COVID-19: a mathematical modelling study. The Lancet Infectious Diseases,
-20(5), 553-558. \url{https://doi.org/10.1016/S1473-3099(20)30144-4}
+20(5), 553-558. \doi{10.1016/S1473-3099(20)30144-4}
 }
 \seealso{
 \code{\link[=probability_extinct]{probability_extinct()}}

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -30,7 +30,7 @@ probability_extinct(R = 1.5, k = 0.1, a = 10)
 \references{
 Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005).
 Superspreading and the effect of individual variation on disease emergence.
-Nature, 438(7066), 355-359. \url{https://doi.org/10.1038/nature04153}
+Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 }
 \seealso{
 \code{\link[=probability_epidemic]{probability_epidemic()}}

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -74,5 +74,5 @@ The analytical calculation is from:
 Endo, A., Abbott, S., Kucharski, A. J., & Funk, S. (2020)
 Estimating the overdispersion in COVID-19 transmission using outbreak
 sizes outside China. Wellcome Open Research, 5.
-<doi.org/10.12688/wellcomeopenres.15842.3>
+\doi{10.12688/wellcomeopenres.15842.3}
 }

--- a/tests/testthat/test-case_to_transmission.R
+++ b/tests/testthat/test-case_to_transmission.R
@@ -108,8 +108,8 @@ test_that("proportion_transmission fails as expected", {
   )
 })
 
-test_that(".proportion_transmission_numerical works as expected", {
-  res <- .proportion_transmission_numerical(
+test_that(".prop_transmission_numerical works as expected", {
+  res <- .prop_transmission_numerical(
     R = 2,
     k = 0.5,
     percent_transmission = 0.8
@@ -118,8 +118,8 @@ test_that(".proportion_transmission_numerical works as expected", {
   expect_length(res, 1)
 })
 
-test_that(".proportion_transmission_analytical works as expected", {
-  res <- .proportion_transmission_analytical(
+test_that(".prop_transmission_analytical works as expected", {
+  res <- .prop_transmission_analytical(
     R = 2,
     k = 0.5,
     percent_transmission = 0.8

--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -85,7 +85,7 @@ to only include those with a single initial infection seeding transmission (`a =
 homogeneity <- subset(epidemic_params, a == 1)
 ```
 
-```{r, plot-dispersion, class.source = 'fold-hide', fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from Kucharski et al. (2020) figure 3A.", fig.width = 8, fig.height = 5}
+```{r, plot-dispersion, class.source = 'fold-hide', fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from @kucharskiEarlyDynamicsTransmission2020 figure 3A.", fig.width = 8, fig.height = 5}
 # plot probability of epidemic across dispersion
 ggplot(data = homogeneity) +
   geom_ribbon(
@@ -115,7 +115,7 @@ ggplot(data = homogeneity) +
   theme_bw()
 ```
 
-The degree of variability in transmission increases as $k$ decreases (@lloyd-smithSuperspreadingEffectIndividual2005). 
+The degree of variability in transmission increases as $k$ decreases [@lloyd-smithSuperspreadingEffectIndividual2005]. 
 So the probability of a large outbreak is smaller for smaller values of $k$, meaning that if COVID-19
 is more similar to SARS than MERS it will be less likely to establish and cause an 
 outbreak if introduced into a newly susceptible population.
@@ -318,3 +318,5 @@ ggplot(data = contain_params) +
     legend.title = element_markdown()
   )
 ```
+
+## References

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -346,3 +346,5 @@ data, whereas the Poisson-Weibull slightly overestimates the number.
 
 Overall, {superspreading} and {fitdistrplus} (or another fitting package of your choice) can be used to estimate and 
 understand individual-level transmission dynamics when transmission chain data is available.
+
+## References

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -31,7 +31,7 @@ accounted for by the population-level reproduction number ($R$).
 ## Definition
 
 Superspreading describes individual heterogeneity in disease transmission, such that some individuals transmit to many infectees while other
-infectors infect few or zero individuals (@lloyd-smithSuperspreadingEffectIndividual2005).
+infectors infect few or zero individuals [@lloyd-smithSuperspreadingEffectIndividual2005].
 :::
 
 ```{r setup}


### PR DESCRIPTION
This PR address miscellaneous changes that were requested as part of the full package review (see #31).

Changes include removing `# nolint` and shortening internal function names, using `\doi{}` in documentation, and formatting references (`@reference` vs. `[@reference]`).