### PR TITLE
Fix {epiparameter} use in {superspreading}

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^\.lintr$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ po/*~
 rsconnect/
 R/.DS_Store
 inst/doc
+/doc/
+/Meta/

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -56,7 +56,7 @@ test_that("probability_contain fails as expected", {
 })
 
 test_that("probability_contain works with <epidist>", {
-  edist <- suppressWarnings(
+  edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring distribution",

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -60,7 +60,8 @@ test_that("probability_contain works with <epidist>", {
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring_distribution",
-      author = "Lloyd-Smith_etal"
+      author = "Lloyd-Smith",
+      single_epidist = TRUE
     )
   )
   expect_equal(

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -59,7 +59,7 @@ test_that("probability_contain works with <epidist>", {
   edist <- suppressWarnings(
     epiparameter::epidist_db(
       disease = "SARS",
-      epi_dist = "offspring_distribution",
+      epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
       single_epidist = TRUE
     )

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -78,7 +78,8 @@ test_that("probability_epidemic works with <epidist>", {
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring_distribution",
-      author = "Lloyd-Smith_etal"
+      author = "Lloyd-Smith",
+      single_epidist = TRUE
     )
   )
   expect_equal(probability_epidemic(num_init_infect = 1, epidist = edist), 0.12)

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -74,7 +74,7 @@ test_that("probability_epidemic works for R > 1", {
 })
 
 test_that("probability_epidemic works with <epidist>", {
-  edist <- suppressWarnings(
+  edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring distribution",

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -77,7 +77,7 @@ test_that("probability_epidemic works with <epidist>", {
   edist <- suppressWarnings(
     epiparameter::epidist_db(
       disease = "SARS",
-      epi_dist = "offspring_distribution",
+      epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
       single_epidist = TRUE
     )

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -76,7 +76,8 @@ test_that("proportion_cluster_size works with <epidist>", {
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring_distribution",
-      author = "Lloyd-Smith_etal"
+      author = "Lloyd-Smith",
+      single_epidist = TRUE
     )
   )
   res <- proportion_cluster_size(cluster_size = 20, epidist = edist)

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -75,7 +75,7 @@ test_that("proportion_cluster_size works with <epidist>", {
   edist <- suppressWarnings(
     epiparameter::epidist_db(
       disease = "SARS",
-      epi_dist = "offspring_distribution",
+      epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
       single_epidist = TRUE
     )

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -72,7 +72,7 @@ test_that("proportion_cluster_size fails as expected", {
 })
 
 test_that("proportion_cluster_size works with <epidist>", {
-  edist <- suppressWarnings(
+  edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring distribution",

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -133,7 +133,8 @@ test_that("proportion_transmission works with <epidist>", {
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring_distribution",
-      author = "Lloyd-Smith_etal"
+      author = "Lloyd-Smith",
+      single_epidist = TRUE
     )
   )
   res <- proportion_transmission(percent_transmission = 0.8, epidist = edist)

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -129,7 +129,7 @@ test_that(".prop_transmission_analytical works as expected", {
 })
 
 test_that("proportion_transmission works with <epidist>", {
-  edist <- suppressWarnings(
+  edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",
       epi_dist = "offspring distribution",

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -132,7 +132,7 @@ test_that("proportion_transmission works with <epidist>", {
   edist <- suppressWarnings(
     epiparameter::epidist_db(
       disease = "SARS",
-      epi_dist = "offspring_distribution",
+      epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
       single_epidist = TRUE
     )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -3,7 +3,8 @@ edist <- suppressWarnings(
   epidist_db(
     disease = "SARS",
     epi_dist = "offspring_distribution",
-    author = "Lloyd-Smith_etal"
+    author = "Lloyd-Smith",
+    single_epidist = TRUE
   )
 )
 
@@ -25,7 +26,8 @@ test_that("get_param fails as expected with incorrect parameters", {
     epidist_db(
       disease = "COVID-19",
       epi_dist = "incubation_period",
-      author = "Linton_etal"
+      author = "Linton",
+      single_epidist = TRUE
     )
   )
   expect_error(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,5 @@
 library(epiparameter)
-edist <- suppressWarnings(
+edist <- suppressMessages(
   epidist_db(
     disease = "SARS",
     epi_dist = "offspring distribution",
@@ -22,7 +22,7 @@ test_that("get_param fails as expected", {
 })
 
 test_that("get_param fails as expected with incorrect parameters", {
-  edist <- suppressWarnings(
+  edist <- suppressMessages(
     epidist_db(
       disease = "COVID-19",
       epi_dist = "incubation period",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,7 +2,7 @@ library(epiparameter)
 edist <- suppressWarnings(
   epidist_db(
     disease = "SARS",
-    epi_dist = "offspring_distribution",
+    epi_dist = "offspring distribution",
     author = "Lloyd-Smith",
     single_epidist = TRUE
   )
@@ -25,7 +25,7 @@ test_that("get_param fails as expected with incorrect parameters", {
   edist <- suppressWarnings(
     epidist_db(
       disease = "COVID-19",
-      epi_dist = "incubation_period",
+      epi_dist = "incubation period",
       author = "Linton",
       single_epidist = TRUE
     )

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -123,12 +123,12 @@ diseases and evaluate how likely they are to cause epidemics.
 ```{r, epiparam}
 sars <- epidist_db(
   disease = "SARS",
-  epi_dist = "offspring distribution", 
+  epi_dist = "offspring distribution",
   single_epidist = TRUE
 )
 evd <- epidist_db(
   disease = "Ebola Virus Disease",
-  epi_dist = "offspring distribution", 
+  epi_dist = "offspring distribution",
   single_epidist = TRUE
 )
 ```
@@ -151,8 +151,8 @@ probability_epidemic(
 )
 family(evd)
 probability_epidemic(
-  R = evd_params[["mean"]], 
-  k = evd_params[["dispersion"]], 
+  R = evd_params[["mean"]],
+  k = evd_params[["dispersion"]],
   num_init_infect = 1
 )
 ```

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -123,12 +123,12 @@ diseases and evaluate how likely they are to cause epidemics.
 ```{r, epiparam}
 sars <- epidist_db(
   disease = "SARS",
-  epi_dist = "offspring_distribution", 
+  epi_dist = "offspring distribution", 
   single_epidist = TRUE
 )
 evd <- epidist_db(
   disease = "Ebola Virus Disease",
-  epi_dist = "offspring_distribution", 
+  epi_dist = "offspring distribution", 
   single_epidist = TRUE
 )
 ```

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -123,11 +123,13 @@ diseases and evaluate how likely they are to cause epidemics.
 ```{r, epiparam}
 sars <- epidist_db(
   disease = "SARS",
-  epi_dist = "offspring_distribution"
+  epi_dist = "offspring_distribution", 
+  single_epidist = TRUE
 )
 evd <- epidist_db(
   disease = "Ebola Virus Disease",
-  epi_dist = "offspring_distribution"
+  epi_dist = "offspring_distribution", 
+  single_epidist = TRUE
 )
 ```
 
@@ -148,8 +150,11 @@ probability_epidemic(
   num_init_infect = 1
 )
 family(evd)
-# k is set to infinite as the distribution for EVD is poisson
-probability_epidemic(R = evd_params[["mean"]], k = Inf, num_init_infect = 1)
+probability_epidemic(
+  R = evd_params[["mean"]], 
+  k = evd_params[["dispersion"]], 
+  num_init_infect = 1
+)
 ```
 
 In the above example we assume the initial pool of infectors is one (`num_init_infect = 1`) 
@@ -157,10 +162,9 @@ but this can easily be adjusted in the case there is evidence for a larger initi
 seeding of infections, whether from animal-to-human spillover or imported cases from outside the area of interest.
 
 We can see that the probability of an epidemic given the estimates of 
-@lloyd-smithSuperspreadingEffectIndividual2005 is greater for SARS than Ebola. 
-This is due to the offspring distribution of Ebola being poisson distributed 
-with a smaller mean (mean $R$ = `r evd_params[["mean"]]`), 
-compared to SARS, which is negative binomially distributed with a relatively
+@lloyd-smithSuperspreadingEffectIndividual2005 is greater for Ebola than SARS.
+This is due to the offspring distribution of Ebola having a larger dispersion 
+(dispersion $k$ = `r evd_params[["dispersion"]]`), compared to SARS, which has a relatively
 small dispersion ($k$ = `r sars_params[["dispersion"]]`).
 
 ## References


### PR DESCRIPTION
This PR addresses #61 by updating the {superspreading} package to use the newest features and accommodate breaking changes from the [{epiparameter} package](https://github.com/epiverse-trace/epiparameter).

The `single_epidist` argument is added to `epidist_db()` calls to ensure only a single `<epidist>` is returned from the function. `suppressMessages()` replaces `suppressWarnings()` when calling `epidist_db()` in tests. The author names given to the `author` argument of `epidist_db()` are updated to remove `"_etal"`. Epidemiological distributions provided to the `epi_dist` argument are now whitespace separated (not necessary but is now the preferred style from {epiparameter}). 

The `superspreading.Rmd` vignette is updated to use the updated Ebola offspring distribution from the {epiparameter} database and updates to the text are made given changes in interpretation of function outputs. 