### PR TITLE
Improve function documentation

### DIFF
--- a/R/offspring_distributions.R
+++ b/R/offspring_distributions.R
@@ -3,10 +3,10 @@
 #' @details The function is vectorised so a vector of quantiles can be input
 #' and the output will have an equal length.
 #'
-#' @param x A `number` for the quantile of the distribution
-#' @param meanlog A `number` for the mean of the distribution on the log scale
+#' @param x A `number` for the quantile of the distribution.
+#' @param meanlog A `number` for the mean of the distribution on the log scale.
 #' @param sdlog A `number` for the standard deviation of the distribution on
-#' the log scale
+#' the log scale.
 #'
 #' @return A `numeric` vector of the density of the poisson-lognormal
 #' distribution.
@@ -43,7 +43,7 @@ dpoislnorm <- Vectorize(function(x, meanlog, sdlog) {
 #' @details The function is vectorised so a vector of quantiles can be input
 #' and the output will have an equal length.
 #'
-#' @param q A `number` for the quantile of the distribution
+#' @param q A `number` for the quantile of the distribution.
 #' @inheritParams dpoislnorm
 #'
 #' @return A `numeric` vector of the distribution function.
@@ -70,9 +70,9 @@ ppoislnorm <- Vectorize(function(q, meanlog, sdlog) {
 #' @details The function is vectorised so a vector of quantiles can be input
 #' and the output will have an equal length.
 #'
-#' @param x A `number` for the quantile of the distribution
-#' @param shape A `number` for the shape parameter of the distribution
-#' @param scale A `number` for the scale parameter of the distribution
+#' @param x A `number` for the quantile of the distribution.
+#' @param shape A `number` for the shape parameter of the distribution.
+#' @param scale A `number` for the scale parameter of the distribution.
 #'
 #' @return A `numeric` vector of the density of the poisson-Weibull
 #' distribution.
@@ -111,7 +111,7 @@ dpoisweibull <- Vectorize(function(x, shape, scale) {
 #' @details The function is vectorised so a vector of quantiles can be input
 #' and the output will have an equal length.
 #'
-#' @param q A `number` for the quantile of the distribution
+#' @param q A `number` for the quantile of the distribution.
 #' @inheritParams dpoisweibull
 #'
 #' @return A `numeric` vector of the distribution function.

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -14,7 +14,7 @@
 #' @param case_threshold A number for the threshold of the number of cases below
 #' which the epidemic is considered contained.
 #'
-#' @return A number for the probability of containment
+#' @return A `number` for the probability of containment.
 #' @export
 #'
 #' @references

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -68,7 +68,7 @@ probability_epidemic <- function(R, k, num_init_infect, ..., epidist) {
   return(prob_epidemic)
 }
 
-#' Calculates the probability a branching process will go extinct based on
+#' Calculate the probability a branching process will go extinct based on
 #' R, k and initial cases
 #'
 #' @description Calculates the probability a branching process will not causes

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -3,18 +3,18 @@
 #'
 #' @description Calculates the probability a branching process will cause an
 #' epidemic (i.e. probability will fail to go extinct) based on R, k and
-#' initial cases
+#' initial cases.
 #'
 #' @param R A `number` specifying the R parameter (i.e. average secondary cases
-#' per infectious individual)
+#' per infectious individual).
 #' @param k A `number` specifying the  k parameter (i.e. overdispersion in
-#' offspring distribution from fitted negative binomial)
-#' @param num_init_infect A `count` specifying the number of initial infections
-#' @param ... [`dots`] not used, extra arguments supplied will cause a warning.
+#' offspring distribution from fitted negative binomial).
+#' @param num_init_infect A `count` specifying the number of initial infections.
+#' @param ... [dots] not used, extra arguments supplied will cause a warning.
 #' @param epidist An `<epidist>` object. An S3 class for working with
-#' epidemiological parameters/distributions, see [`epiparameter::epidist()`]
+#' epidemiological parameters/distributions, see [epiparameter::epidist()].
 #'
-#' @return A value with the probability of a large epidemic
+#' @return A value with the probability of a large epidemic.
 #' @export
 #' @seealso [probability_extinct()]
 #'
@@ -73,11 +73,11 @@ probability_epidemic <- function(R, k, num_init_infect, ..., epidist) {
 #'
 #' @description Calculates the probability a branching process will not causes
 #' an epidemic and will go extinct. This is the complement of the probability
-#' of a disease causing an epidemic ([`probability_epidemic()`]).
+#' of a disease causing an epidemic ([probability_epidemic()]).
 #'
 #' @inheritParams probability_epidemic
 #'
-#' @return A value with the probability of going extinct
+#' @return A value with the probability of going extinct.
 #' @export
 #' @seealso [probability_epidemic()]
 #'

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -1,6 +1,6 @@
 #' Proportion of new cases that originated with a transmission event of a
 #' given size (useful to inform backwards contact tracing efforts, i.e. how
-#' many cases are associated with large clusters).
+#' many cases are associated with large clusters)
 #'
 #' @description Calculates the proportion of new cases that originated with a
 #' transmission event of a given size (useful to inform backwards contact
@@ -14,13 +14,14 @@
 #' cases of a certain size. In other words it is the number of cases above a
 #' threshold divided by the total number of cases, not the number of
 #' transmission events above a certain threshold divided by the number of
-#' transmission events
+#' transmission events.
 #'
 #' @inheritParams probability_epidemic
-#' @param cluster_size A `number` for the cluster size threshold
+#' @param cluster_size A `number` for the cluster size threshold.
 #'
-#' @return A data frame with the value for the proportion of new cases that are
-#' part of a transmission event above a threshold for a given value of R and k
+#' @return A `<data.frame>` with the value for the proportion of new cases
+#' that are part of a transmission event above a threshold for a given value
+#' of R and k.
 #' @export
 #'
 #' @examples

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -22,8 +22,8 @@
 #' @param sim A `logical` whether the calculation should be done numerically
 #' (i.e. simulate secondary contacts) or analytically.
 #'
-#' @return A `<data.frame>` with the value for the proportion of cases for a given
-#' value of R and k.
+#' @return A `<data.frame>` with the value for the proportion of cases for a
+#' given value of R and k.
 #' @export
 #'
 #' @references

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -83,7 +83,7 @@ proportion_transmission <- function(R, k,
   checkmate::assert_number(percent_transmission, lower = 0, upper = 1)
   checkmate::assert_logical(sim, any.missing = FALSE, len = 1)
 
-  df <- expand.grid("R" = R, "k" = k, NA_real_)
+  df <- expand.grid(R = R, k = k, NA_real_)
   colnames(df) <- c("R", "k", paste0("prop_", percent_transmission * 100))
 
   for (i in seq_len(nrow(df))) {

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -9,7 +9,7 @@
 #' This can be calculated using `proportion_transmission()` at varying values of
 #' \eqn{R} and for different values of percentage transmission.
 #'
-#' @details Multiple values of R and k can be supplied and a data frame of
+#' @details Multiple values of R and k can be supplied and a `<data.frame>` of
 #' every combination of these will be returned.
 #'
 #' The numerical calculation uses random number generation to simulate secondary
@@ -18,12 +18,12 @@
 #'
 #' @inheritParams probability_epidemic
 #' @param percent_transmission A `number` of the percentage transmission
-#' for which a proportion of cases has produced
+#' for which a proportion of cases has produced.
 #' @param sim A `logical` whether the calculation should be done numerically
-#' (i.e. simulate secondary contacts) or analytically
+#' (i.e. simulate secondary contacts) or analytically.
 #'
-#' @return A data frame with the value for the proportion of cases for a given
-#' value of R and k
+#' @return A `<data.frame>` with the value for the proportion of cases for a given
+#' value of R and k.
 #' @export
 #'
 #' @references

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,7 +3,7 @@
 #' @inheritParams probability_epidemic
 #' @param parameter A character string, either `"R"` or `"k"`.
 #'
-#' @return An unnamed numeric
+#' @return An unnamed numeric.
 #' @keywords internal
 #' @noRd
 get_epidist_param <- function(epidist,

--- a/man/dpoislnorm.Rd
+++ b/man/dpoislnorm.Rd
@@ -7,12 +7,12 @@
 dpoislnorm(x, meanlog, sdlog)
 }
 \arguments{
-\item{x}{A \code{number} for the quantile of the distribution}
+\item{x}{A \code{number} for the quantile of the distribution.}
 
-\item{meanlog}{A \code{number} for the mean of the distribution on the log scale}
+\item{meanlog}{A \code{number} for the mean of the distribution on the log scale.}
 
 \item{sdlog}{A \code{number} for the standard deviation of the distribution on
-the log scale}
+the log scale.}
 }
 \value{
 A \code{numeric} vector of the density of the poisson-lognormal

--- a/man/dpoisweibull.Rd
+++ b/man/dpoisweibull.Rd
@@ -7,11 +7,11 @@
 dpoisweibull(x, shape, scale)
 }
 \arguments{
-\item{x}{A \code{number} for the quantile of the distribution}
+\item{x}{A \code{number} for the quantile of the distribution.}
 
-\item{shape}{A \code{number} for the shape parameter of the distribution}
+\item{shape}{A \code{number} for the shape parameter of the distribution.}
 
-\item{scale}{A \code{number} for the scale parameter of the distribution}
+\item{scale}{A \code{number} for the scale parameter of the distribution.}
 }
 \value{
 A \code{numeric} vector of the density of the poisson-Weibull

--- a/man/ppoislnorm.Rd
+++ b/man/ppoislnorm.Rd
@@ -8,12 +8,12 @@ distribution}
 ppoislnorm(q, meanlog, sdlog)
 }
 \arguments{
-\item{q}{A \code{number} for the quantile of the distribution}
+\item{q}{A \code{number} for the quantile of the distribution.}
 
-\item{meanlog}{A \code{number} for the mean of the distribution on the log scale}
+\item{meanlog}{A \code{number} for the mean of the distribution on the log scale.}
 
 \item{sdlog}{A \code{number} for the standard deviation of the distribution on
-the log scale}
+the log scale.}
 }
 \value{
 A \code{numeric} vector of the distribution function.

--- a/man/ppoisweibull.Rd
+++ b/man/ppoisweibull.Rd
@@ -8,11 +8,11 @@ distribution}
 ppoisweibull(q, shape, scale)
 }
 \arguments{
-\item{q}{A \code{number} for the quantile of the distribution}
+\item{q}{A \code{number} for the quantile of the distribution.}
 
-\item{shape}{A \code{number} for the shape parameter of the distribution}
+\item{shape}{A \code{number} for the shape parameter of the distribution.}
 
-\item{scale}{A \code{number} for the scale parameter of the distribution}
+\item{scale}{A \code{number} for the scale parameter of the distribution.}
 }
 \value{
 A \code{numeric} vector of the distribution function.

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -18,12 +18,12 @@ probability_contain(
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
-per infectious individual)}
+per infectious individual).}
 
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
-offspring distribution from fitted negative binomial)}
+offspring distribution from fitted negative binomial).}
 
-\item{num_init_infect}{A \code{count} specifying the number of initial infections}
+\item{num_init_infect}{A \code{count} specifying the number of initial infections.}
 
 \item{control}{Control strength, 0 is no control measures, 1 is complete
 control.}
@@ -40,10 +40,10 @@ probability of extinction.}
 which the epidemic is considered contained.}
 
 \item{epidist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}}
+epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A number for the probability of containment
+A \code{number} for the probability of containment.
 }
 \description{
 Containment is defined as the size of the transmission chain

--- a/man/probability_epidemic.Rd
+++ b/man/probability_epidemic.Rd
@@ -9,25 +9,25 @@ probability_epidemic(R, k, num_init_infect, ..., epidist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
-per infectious individual)}
+per infectious individual).}
 
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
-offspring distribution from fitted negative binomial)}
+offspring distribution from fitted negative binomial).}
 
-\item{num_init_infect}{A \code{count} specifying the number of initial infections}
+\item{num_init_infect}{A \code{count} specifying the number of initial infections.}
 
-\item{...}{\code{\link{dots}} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
 \item{epidist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}}
+epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A value with the probability of a large epidemic
+A value with the probability of a large epidemic.
 }
 \description{
 Calculates the probability a branching process will cause an
 epidemic (i.e. probability will fail to go extinct) based on R, k and
-initial cases
+initial cases.
 }
 \examples{
 probability_epidemic(R = 1.5, k = 0.1, num_init_infect = 10)

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/probability_epidemic.R
 \name{probability_extinct}
 \alias{probability_extinct}
-\title{Calculates the probability a branching process will go extinct based on
+\title{Calculate the probability a branching process will go extinct based on
 R, k and initial cases}
 \usage{
 probability_extinct(R, k, num_init_infect, ..., epidist)

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -9,20 +9,20 @@ probability_extinct(R, k, num_init_infect, ..., epidist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
-per infectious individual)}
+per infectious individual).}
 
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
-offspring distribution from fitted negative binomial)}
+offspring distribution from fitted negative binomial).}
 
-\item{num_init_infect}{A \code{count} specifying the number of initial infections}
+\item{num_init_infect}{A \code{count} specifying the number of initial infections.}
 
-\item{...}{\code{\link{dots}} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
 \item{epidist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}}
+epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A value with the probability of going extinct
+A value with the probability of going extinct.
 }
 \description{
 Calculates the probability a branching process will not causes

--- a/man/proportion_cluster_size.Rd
+++ b/man/proportion_cluster_size.Rd
@@ -4,27 +4,28 @@
 \alias{proportion_cluster_size}
 \title{Proportion of new cases that originated with a transmission event of a
 given size (useful to inform backwards contact tracing efforts, i.e. how
-many cases are associated with large clusters).}
+many cases are associated with large clusters)}
 \usage{
 proportion_cluster_size(R, k, cluster_size, ..., epidist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
-per infectious individual)}
+per infectious individual).}
 
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
-offspring distribution from fitted negative binomial)}
+offspring distribution from fitted negative binomial).}
 
-\item{cluster_size}{A \code{number} for the cluster size threshold}
+\item{cluster_size}{A \code{number} for the cluster size threshold.}
 
-\item{...}{\code{\link{dots}} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
 \item{epidist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}}
+epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A data frame with the value for the proportion of new cases that are
-part of a transmission event above a threshold for a given value of R and k
+A \verb{<data.frame>} with the value for the proportion of new cases
+that are part of a transmission event above a threshold for a given value
+of R and k.
 }
 \description{
 Calculates the proportion of new cases that originated with a
@@ -40,7 +41,7 @@ the proportion of transmission events that cause a cluster of secondary
 cases of a certain size. In other words it is the number of cases above a
 threshold divided by the total number of cases, not the number of
 transmission events above a certain threshold divided by the number of
-transmission events
+transmission events.
 }
 \examples{
 R <- 2

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -26,8 +26,8 @@ for which a proportion of cases has produced.}
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A \verb{<data.frame>} with the value for the proportion of cases for a given
-value of R and k.
+A \verb{<data.frame>} with the value for the proportion of cases for a
+given value of R and k.
 }
 \description{
 Calculates the proportion of cases that cause a certain

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -9,25 +9,25 @@ proportion_transmission(R, k, percent_transmission, sim = FALSE, ..., epidist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
-per infectious individual)}
+per infectious individual).}
 
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
-offspring distribution from fitted negative binomial)}
+offspring distribution from fitted negative binomial).}
 
 \item{percent_transmission}{A \code{number} of the percentage transmission
-for which a proportion of cases has produced}
+for which a proportion of cases has produced.}
 
 \item{sim}{A \code{logical} whether the calculation should be done numerically
-(i.e. simulate secondary contacts) or analytically}
+(i.e. simulate secondary contacts) or analytically.}
 
-\item{...}{\code{\link{dots}} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
 \item{epidist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}}
+epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{
-A data frame with the value for the proportion of cases for a given
-value of R and k
+A \verb{<data.frame>} with the value for the proportion of cases for a given
+value of R and k.
 }
 \description{
 Calculates the proportion of cases that cause a certain
@@ -39,7 +39,7 @@ This can be calculated using \code{proportion_transmission()} at varying values 
 \eqn{R} and for different values of percentage transmission.
 }
 \details{
-Multiple values of R and k can be supplied and a data frame of
+Multiple values of R and k can be supplied and a \verb{<data.frame>} of
 every combination of these will be returned.
 
 The numerical calculation uses random number generation to simulate secondary


### PR DESCRIPTION
This PR improves the consistency and style of the function documentation within {superspreading}. This involves consistently using imperative function titles (#35), use `<>` notation for S3 classes, remove backticks (\`\`) when linking (i.e. `[pkg::func()]`), and full stops after sentences.