### PR TITLE
Update function arguments accepting `<epidist>`

### DIFF
--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -30,16 +30,16 @@ probability_contain <- function(R, k, num_init_infect = 1, control,
                                 stochastic = TRUE,
                                 ...,
                                 case_threshold = 100,
-                                epidist) {
+                                offspring_dist) {
   input_params <- missing(R) && missing(k)
-  if (!xor(input_params, missing(epidist))) {
+  if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
   }
   # check inputs
   if (input_params) {
-    epiparameter::is_epidist(epidist)
-    R <- get_epidist_param(epidist = epidist, parameter = "R")
-    k <- get_epidist_param(epidist = epidist, parameter = "k")
+    epiparameter::is_epidist(offspring_dist)
+    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
+    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }
   checkmate::assert_number(R, lower = 0, finite = TRUE)
   checkmate::assert_number(k, lower = 0)

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -37,7 +37,7 @@ probability_contain <- function(R, k, num_init_infect = 1, control,
   }
   # check inputs
   if (input_params) {
-    epiparameter::is_epidist(offspring_dist)
+    checkmate::assert_class(offspring_dist, classes = "epidist")
     R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
     k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -36,7 +36,7 @@ probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(offspring_dist)
+    checkmate::assert_class(offspring_dist, classes = "epidist")
     R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
     k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -11,7 +11,7 @@
 #' offspring distribution from fitted negative binomial).
 #' @param num_init_infect A `count` specifying the number of initial infections.
 #' @param ... [dots] not used, extra arguments supplied will cause a warning.
-#' @param epidist An `<epidist>` object. An S3 class for working with
+#' @param offspring_dist An `<epidist>` object. An S3 class for working with
 #' epidemiological parameters/distributions, see [epiparameter::epidist()].
 #'
 #' @return A value with the probability of a large epidemic.
@@ -27,18 +27,18 @@
 #'
 #' @examples
 #' probability_epidemic(R = 1.5, k = 0.1, num_init_infect = 10)
-probability_epidemic <- function(R, k, num_init_infect, ..., epidist) {
+probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
   input_params <- missing(R) && missing(k)
-  if (!xor(input_params, missing(epidist))) {
+  if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(epidist)
-    R <- get_epidist_param(epidist = epidist, parameter = "R")
-    k <- get_epidist_param(epidist = epidist, parameter = "k")
+    epiparameter::is_epidist(offspring_dist)
+    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
+    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }
 
   checkmate::assert_number(R, lower = 0, finite = TRUE)
@@ -89,9 +89,13 @@ probability_epidemic <- function(R, k, num_init_infect, ..., epidist) {
 #'
 #' @examples
 #' probability_extinct(R = 1.5, k = 0.1, num_init_infect = 10)
-probability_extinct <- function(R, k, num_init_infect, ..., epidist) {
+probability_extinct <- function(R, k, num_init_infect, ..., offspring_dist) {
   # input checking done in probability_epidemic
   1 - probability_epidemic(
-    R = R, k = k, num_init_infect = num_init_infect, ..., epidist = epidist
+    R = R,
+    k = k,
+    num_init_infect = num_init_infect,
+    ...,
+    offspring_dist = offspring_dist
   )
 }

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -37,18 +37,18 @@
 #' # example with a vector of cluster sizes
 #' cluster_size <- c(5, 10, 25)
 #' proportion_cluster_size(R = R, k = k, cluster_size = cluster_size)
-proportion_cluster_size <- function(R, k, cluster_size, ..., epidist) {
+proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist) {
   input_params <- missing(R) && missing(k)
-  if (!xor(input_params, missing(epidist))) {
+  if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(epidist)
-    R <- get_epidist_param(epidist = epidist, parameter = "R")
-    k <- get_epidist_param(epidist = epidist, parameter = "k")
+    epiparameter::is_epidist(offspring_dist)
+    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
+    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -46,7 +46,7 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist) {
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(offspring_dist)
+    checkmate::assert_class(offspring_dist, classes = "epidist")
     R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
     k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -74,7 +74,7 @@ proportion_transmission <- function(R, k,
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(offspring_dist)
+    checkmate::assert_class(offspring_dist, classes = "epidist")
     R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
     k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -65,18 +65,18 @@ proportion_transmission <- function(R, k,
                                     percent_transmission,
                                     sim = FALSE,
                                     ...,
-                                    epidist) {
+                                    offspring_dist) {
   input_params <- missing(R) && missing(k)
-  if (!xor(input_params, missing(epidist))) {
+  if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs
   chkDots(...)
   if (input_params) {
-    epiparameter::is_epidist(epidist)
-    R <- get_epidist_param(epidist = epidist, parameter = "R")
-    k <- get_epidist_param(epidist = epidist, parameter = "k")
+    epiparameter::is_epidist(offspring_dist)
+    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
+    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
   }
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -13,7 +13,7 @@ probability_contain(
   stochastic = TRUE,
   ...,
   case_threshold = 100,
-  epidist
+  offspring_dist
 )
 }
 \arguments{
@@ -39,7 +39,7 @@ probability of extinction.}
 \item{case_threshold}{A number for the threshold of the number of cases below
 which the epidemic is considered contained.}
 
-\item{epidist}{An \verb{<epidist>} object. An S3 class for working with
+\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{

--- a/man/probability_epidemic.Rd
+++ b/man/probability_epidemic.Rd
@@ -5,7 +5,7 @@
 \title{Calculate the probability a disease will cause an outbreak based on R, k
 and initial cases}
 \usage{
-probability_epidemic(R, k, num_init_infect, ..., epidist)
+probability_epidemic(R, k, num_init_infect, ..., offspring_dist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -18,7 +18,7 @@ offspring distribution from fitted negative binomial).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{epidist}{An \verb{<epidist>} object. An S3 class for working with
+\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -5,7 +5,7 @@
 \title{Calculate the probability a branching process will go extinct based on
 R, k and initial cases}
 \usage{
-probability_extinct(R, k, num_init_infect, ..., epidist)
+probability_extinct(R, k, num_init_infect, ..., offspring_dist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -18,7 +18,7 @@ offspring distribution from fitted negative binomial).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{epidist}{An \verb{<epidist>} object. An S3 class for working with
+\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{

--- a/man/proportion_cluster_size.Rd
+++ b/man/proportion_cluster_size.Rd
@@ -6,7 +6,7 @@
 given size (useful to inform backwards contact tracing efforts, i.e. how
 many cases are associated with large clusters)}
 \usage{
-proportion_cluster_size(R, k, cluster_size, ..., epidist)
+proportion_cluster_size(R, k, cluster_size, ..., offspring_dist)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -19,7 +19,7 @@ offspring distribution from fitted negative binomial).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{epidist}{An \verb{<epidist>} object. An S3 class for working with
+\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -5,7 +5,14 @@
 \title{Estimate what proportion of cases that cause a certain proportion of
 transmission}
 \usage{
-proportion_transmission(R, k, percent_transmission, sim = FALSE, ..., epidist)
+proportion_transmission(
+  R,
+  k,
+  percent_transmission,
+  sim = FALSE,
+  ...,
+  offspring_dist
+)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -22,7 +29,7 @@ for which a proportion of cases has produced.}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{epidist}{An \verb{<epidist>} object. An S3 class for working with
+\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
 }
 \value{

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -66,7 +66,10 @@ test_that("probability_contain works with <epidist>", {
   )
   expect_equal(
     probability_contain(
-      num_init_infect = 1, control = 0.1, stochastic = FALSE, epidist = edist
+      num_init_infect = 1,
+      control = 0.1,
+      stochastic = FALSE,
+      offspring_dist = edist
     ),
     0.904
   )

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -82,7 +82,10 @@ test_that("probability_epidemic works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  expect_equal(probability_epidemic(num_init_infect = 1, epidist = edist), 0.12)
+  expect_equal(
+    probability_epidemic(num_init_infect = 1, offspring_dist = edist),
+    0.12
+  )
 })
 
 test_that("probability_epidemic fails without R and k or <epidist>", {

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -80,7 +80,7 @@ test_that("proportion_cluster_size works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  res <- proportion_cluster_size(cluster_size = 20, epidist = edist)
+  res <- proportion_cluster_size(cluster_size = 20, offspring_dist = edist)
 
   expect_s3_class(res, "data.frame")
   expect_identical(dim(res), c(1L, 3L))

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -137,7 +137,10 @@ test_that("proportion_transmission works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  res <- proportion_transmission(percent_transmission = 0.8, epidist = edist)
+  res <- proportion_transmission(
+    percent_transmission = 0.8,
+    offspring_dist = edist
+  )
 
   expect_s3_class(res, "data.frame")
   expect_identical(dim(res), c(1L, 3L))


### PR DESCRIPTION
This PR updates the function arguments to follow the Epiverse-TRACE style of naming a distribution by it's epidemiological name rather than it's data structure or other naming convention. Therefore, all `epidist` arguments are renamed to `offspring_dist`. This naming is consistent with argument naming of the [{epichains} package](https://github.com/epiverse-trace/epichains).

The `<epidist>` objects passed into these functions are now checked with a `checkmate::assert_class()` instead of the previous `epiparameter::is_epidist()` which would not have errored.

__Side note__ (relates #32)
The newly named `offspring_dist` argument still only accepts `<epidist>` objects as opposed to the [{simulist}](https://github.com/epiverse-trace/simulist) and [{cfr}](https://github.com/epiverse-trace/cfr) packages that accept an anonymous function. This is due to the different use of the `<epidist>` object between this package and those. {superspreading} uses `<epidist>` objects as a convenient way to pass parameters of the offspring distribution into the functions. Whereas {simulist} and {cfr} use distribution functions/methods (density, cdf and RNG functions). Therefore, I see no use case for passing an anonymous function to the `offspring_dist` argument in {superspreading}. Additionally, if anonymous functions where accepted then the parameter values would need to be extracted from the function body which seem overly involved for seemingly little return. 