### PR TITLE
Remove mention of {quickfit}

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -75,6 +75,5 @@ infectees
 infectors
 infty
 poisson
-quickfit
 SARS
 wellcomeopenres

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -35,8 +35,7 @@ This vignette demonstrates how to use the {superspreading} and {fitdistrplus} R
 packages to estimate the parameters of individual-level transmission and select
 the best fitting model.
 
-Additionally, {ggplot2} is used for plotting and {quickfit} is used to assist with
-multiple model fitting and comparison.
+Additionally, {ggplot2} is used for plotting.
 
 ```{r setup}
 library(superspreading)
@@ -74,7 +73,6 @@ all_cases <- c(
 # - Geometric
 # - Negative Binomial
 
-# TODO: use {quickfit} for model comparison
 pois_fit <- fitdist(data = all_cases, distr = "pois")
 geom_fit <- fitdist(data = all_cases, distr = "geom")
 nbinom_fit <- fitdist(data = all_cases, distr = "nbinom")
@@ -238,7 +236,6 @@ These functions can be used with {fitdistrplus}, as shown for the other distribu
 # - Poisson-lognormal compound
 # - Poisson-Weibull compound
 
-# TODO: use {quickfit} for model comparison
 pois_fit <- fitdist(data = all_cases, distr = "pois")
 geom_fit <- fitdist(data = all_cases, distr = "geom")
 nbinom_fit <- fitdist(data = all_cases, distr = "nbinom")


### PR DESCRIPTION
This PR removes any reference to the [{quickfit} package](https://github.com/epiverse-trace/quickfit). The initial plan was to utilise {quickfit} to handle any fitting tasks within {superspreading}, however this is not needed for now (taken care of by [{fitdistrplus}](https://cran.r-project.org/package=fitdistrplus)) and as {quickfit} is not a CRAN package it may inhibit development and be an unnecessary interdependence. Until {quickfit} has matured and been released it will not be taken on as a dependency in {superspreading}.