### PR TITLE
Include population-level and individual-level controls in joint framework

### DIFF
--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -13,6 +13,7 @@
 #'
 #' @return A `number` for the probability of containment.
 #' @export
+#' @seealso [probability_extinct()]
 #'
 #' @references
 #'

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -5,7 +5,8 @@
 #'
 #' @inheritParams probability_epidemic
 #' @param stochastic Whether to use a stochastic branching process model or the
-#' probability of extinction.
+#' analytical probability of extinction. Default (`FALSE`) is to use the
+#' analytical calculation.
 #' @param ... arguments to be passed to [bpmodels::chain_sim()].
 #' @param case_threshold A number for the threshold of the number of cases below
 #' which the epidemic is considered contained.
@@ -26,7 +27,7 @@ probability_contain <- function(R,
                                 num_init_infect = 1,
                                 ind_control = 0,
                                 pop_control = 0,
-                                stochastic = TRUE,
+                                stochastic = FALSE,
                                 ...,
                                 case_threshold = 100,
                                 offspring_dist) {

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -22,10 +22,26 @@
 #' Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 #'
 #' @examples
-#' probability_contain(R = 1.5, k = 0.5, control = 1)
+#' # population-level control measures
+#' probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1)
+#'
+#' # individual-level control measures
+#' probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1)
+#'
+#' # both levels of control measures
+#' probability_contain(
+#'   R = 1.5,
+#'   k = 0.5,
+#'   num_init_infect = 1,
+#'   ind_control = 0.1,
+#'   pop_control = 0.1
+#' )
+#'
+#' # multi initial infections with population-level control measures
+#' probability_contain(R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1)
 probability_contain <- function(R,
                                 k,
-                                num_init_infect = 1,
+                                num_init_infect,
                                 ind_control = 0,
                                 pop_control = 0,
                                 stochastic = FALSE,

--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -4,10 +4,6 @@
 #' not reaching the `case_threshold` (default = 100).
 #'
 #' @inheritParams probability_epidemic
-#' @param control Control strength, 0 is no control measures, 1 is complete
-#' control.
-#' @param control_type Either `"population"` or `"individual"` for
-#' population-level or individual-level control measures.
 #' @param stochastic Whether to use a stochastic branching process model or the
 #' probability of extinction.
 #' @param ... arguments to be passed to [bpmodels::chain_sim()].
@@ -25,8 +21,11 @@
 #'
 #' @examples
 #' probability_contain(R = 1.5, k = 0.5, control = 1)
-probability_contain <- function(R, k, num_init_infect = 1, control,
-                                control_type = c("population", "individual"),
+probability_contain <- function(R,
+                                k,
+                                num_init_infect = 1,
+                                ind_control = 0,
+                                pop_control = 0,
                                 stochastic = TRUE,
                                 ...,
                                 case_threshold = 100,
@@ -44,20 +43,14 @@ probability_contain <- function(R, k, num_init_infect = 1, control,
   checkmate::assert_number(R, lower = 0, finite = TRUE)
   checkmate::assert_number(k, lower = 0)
   checkmate::assert_count(num_init_infect)
-  checkmate::assert_number(control, lower = 0, upper = 1)
+  checkmate::assert_number(ind_control, lower = 0, upper = 1)
+  checkmate::assert_number(pop_control, lower = 0, upper = 1)
   checkmate::assert_logical(stochastic, any.missing = FALSE, len = 1)
   checkmate::assert_number(case_threshold, lower = 1)
 
-  control_type <- match.arg(control_type)
-  if (control_type == "population") {
-    R <- (1 - control) * R
-  } else {
-    stop("individual-level controls not yet implemented", call. = FALSE)
-  }
-
-  if (num_init_infect != 1) {
+  if (ind_control > 0 && stochastic) {
     stop(
-      "Multiple introductions is not yet implemented for probability_contain",
+      "individual-level control not yet implemented for stochastic calculation",
       call. = FALSE
     )
   }
@@ -68,22 +61,27 @@ probability_contain <- function(R, k, num_init_infect = 1, control,
       n = 1e5,
       offspring = "nbinom",
       size = k,
-      mu = R,
+      mu = (1 - pop_control) * R,
       infinite = case_threshold
     )
 
     # replace default args if in dots (remove args not for chain_sim)
     args <- utils::modifyList(args, list(...)[...names() %in% names(args)])
 
-    chain_size <- do.call(
-      bpmodels::chain_sim,
-      args
+    chain_size <- lapply(
+      seq_len(num_init_infect),
+      function(x) do.call(bpmodels::chain_sim, args)
     )
-
-    prob_contain <- sum(!is.infinite(chain_size)) / length(chain_size)
+    control_chain_size <- lapply(chain_size, is.infinite)
+    control_chain_size <- Reduce(f = `+`, x = control_chain_size)
+    prob_contain <- sum(control_chain_size == 0) / length(control_chain_size)
   } else {
     prob_contain <- probability_extinct(
-      R = R, k = k, num_init_infect = num_init_infect
+      R = R,
+      k = k,
+      num_init_infect = num_init_infect,
+      ind_control = ind_control,
+      pop_control = pop_control
     )
   }
   return(prob_contain)

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -111,8 +111,8 @@ probability_epidemic <- function(R,
 probability_extinct <- function(R,
                                 k,
                                 num_init_infect,
-                                ind_control,
-                                pop_control,
+                                ind_control = 0,
+                                pop_control = 0,
                                 ...,
                                 offspring_dist) {
   # input checking done in probability_epidemic

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -10,6 +10,10 @@
 #' @param k A `number` specifying the  k parameter (i.e. overdispersion in
 #' offspring distribution from fitted negative binomial).
 #' @param num_init_infect A `count` specifying the number of initial infections.
+#' @param ind_control A `numeric` specifying the strength of individual-level
+#' control measures. Between `0` (default) and `1` (maximum).
+#' @param pop_control A `numeric` specifying the strength of population-level
+#' control measures. Between `0` (default) and `1` (maximum).
 #' @param ... [dots] not used, extra arguments supplied will cause a warning.
 #' @param offspring_dist An `<epidist>` object. An S3 class for working with
 #' epidemiological parameters/distributions, see [epiparameter::epidist()].
@@ -20,6 +24,10 @@
 #'
 #' @references
 #'
+#' Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)
+#' Superspreading and the effect of individual variation on disease emergence.
+#' Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
+#'
 #' Kucharski, A. J., Russell, T. W., Diamond, C., Liu, Y., Edmunds, J.,
 #' Funk, S. & Eggo, R. M. (2020). Early dynamics of transmission and control
 #' of COVID-19: a mathematical modelling study. The Lancet Infectious Diseases,
@@ -27,7 +35,13 @@
 #'
 #' @examples
 #' probability_epidemic(R = 1.5, k = 0.1, num_init_infect = 10)
-probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
+probability_epidemic <- function(R,
+                                 k,
+                                 num_init_infect,
+                                 ind_control = 0,
+                                 pop_control = 0,
+                                 ...,
+                                 offspring_dist) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
@@ -44,6 +58,8 @@ probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
   checkmate::assert_number(R, lower = 0, finite = TRUE)
   checkmate::assert_number(k, lower = 0)
   checkmate::assert_count(num_init_infect)
+  checkmate::assert_number(ind_control, lower = 0, upper = 1)
+  checkmate::assert_number(pop_control, lower = 0, upper = 1)
 
   # change Inf k to 1e10 to prevent issue with grid search
   if (is.infinite(k)) k <- 1e10
@@ -57,7 +73,10 @@ probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
     # set up grid search
     ss <- seq(0.001, 0.999, 0.001)
     # define loss function
-    calculate_prob <- abs((1 + (R / k) * (1 - ss))^(-k) - ss)
+    calculate_prob <- abs(
+      ind_control + (1 - ind_control) *
+        (1 + (((1 - pop_control) * R) / k) * (1 - ss))^(-k) - ss
+    )
     # calculate probability of extinction
     prob_est <- ss[which.min(calculate_prob)]
   }
@@ -89,12 +108,20 @@ probability_epidemic <- function(R, k, num_init_infect, ..., offspring_dist) {
 #'
 #' @examples
 #' probability_extinct(R = 1.5, k = 0.1, num_init_infect = 10)
-probability_extinct <- function(R, k, num_init_infect, ..., offspring_dist) {
+probability_extinct <- function(R,
+                                k,
+                                num_init_infect,
+                                ind_control,
+                                pop_control,
+                                ...,
+                                offspring_dist) {
   # input checking done in probability_epidemic
   1 - probability_epidemic(
     R = R,
     k = k,
     num_init_infect = num_init_infect,
+    ind_control = ind_control,
+    pop_control = pop_control,
     ...,
     offspring_dist = offspring_dist
   )

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -7,7 +7,7 @@
 probability_contain(
   R,
   k,
-  num_init_infect = 1,
+  num_init_infect,
   ind_control = 0,
   pop_control = 0,
   stochastic = FALSE,
@@ -51,7 +51,23 @@ Containment is defined as the size of the transmission chain
 not reaching the \code{case_threshold} (default = 100).
 }
 \examples{
-probability_contain(R = 1.5, k = 0.5, control = 1)
+# population-level control measures
+probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1)
+
+# individual-level control measures
+probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1)
+
+# both levels of control measures
+probability_contain(
+  R = 1.5,
+  k = 0.5,
+  num_init_infect = 1,
+  ind_control = 0.1,
+  pop_control = 0.1
+)
+
+# multi initial infections with population-level control measures
+probability_contain(R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1)
 }
 \references{
 Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -10,7 +10,7 @@ probability_contain(
   num_init_infect = 1,
   ind_control = 0,
   pop_control = 0,
-  stochastic = TRUE,
+  stochastic = FALSE,
   ...,
   case_threshold = 100,
   offspring_dist
@@ -32,7 +32,8 @@ control measures. Between \code{0} (default) and \code{1} (maximum).}
 control measures. Between \code{0} (default) and \code{1} (maximum).}
 
 \item{stochastic}{Whether to use a stochastic branching process model or the
-probability of extinction.}
+analytical probability of extinction. Default (\code{FALSE}) is to use the
+analytical calculation.}
 
 \item{...}{arguments to be passed to \code{\link[bpmodels:chain_sim]{bpmodels::chain_sim()}}.}
 

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -8,8 +8,8 @@ probability_contain(
   R,
   k,
   num_init_infect = 1,
-  control,
-  control_type = c("population", "individual"),
+  ind_control = 0,
+  pop_control = 0,
   stochastic = TRUE,
   ...,
   case_threshold = 100,
@@ -25,11 +25,11 @@ offspring distribution from fitted negative binomial).}
 
 \item{num_init_infect}{A \code{count} specifying the number of initial infections.}
 
-\item{control}{Control strength, 0 is no control measures, 1 is complete
-control.}
+\item{ind_control}{A \code{numeric} specifying the strength of individual-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
 
-\item{control_type}{Either \code{"population"} or \code{"individual"} for
-population-level or individual-level control measures.}
+\item{pop_control}{A \code{numeric} specifying the strength of population-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
 
 \item{stochastic}{Whether to use a stochastic branching process model or the
 probability of extinction.}

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -58,3 +58,6 @@ Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)
 Superspreading and the effect of individual variation on disease emergence.
 Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
 }
+\seealso{
+\code{\link[=probability_extinct]{probability_extinct()}}
+}

--- a/man/probability_epidemic.Rd
+++ b/man/probability_epidemic.Rd
@@ -5,7 +5,15 @@
 \title{Calculate the probability a disease will cause an outbreak based on R, k
 and initial cases}
 \usage{
-probability_epidemic(R, k, num_init_infect, ..., offspring_dist)
+probability_epidemic(
+  R,
+  k,
+  num_init_infect,
+  ind_control = 0,
+  pop_control = 0,
+  ...,
+  offspring_dist
+)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -15,6 +23,12 @@ per infectious individual).}
 offspring distribution from fitted negative binomial).}
 
 \item{num_init_infect}{A \code{count} specifying the number of initial infections.}
+
+\item{ind_control}{A \code{numeric} specifying the strength of individual-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
+
+\item{pop_control}{A \code{numeric} specifying the strength of population-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
@@ -33,6 +47,10 @@ initial cases.
 probability_epidemic(R = 1.5, k = 0.1, num_init_infect = 10)
 }
 \references{
+Lloyd-Smith, J. O., Schreiber, S. J., Kopp, P. E., & Getz, W. M. (2005)
+Superspreading and the effect of individual variation on disease emergence.
+Nature, 438(7066), 355-359. \doi{10.1038/nature04153}
+
 Kucharski, A. J., Russell, T. W., Diamond, C., Liu, Y., Edmunds, J.,
 Funk, S. & Eggo, R. M. (2020). Early dynamics of transmission and control
 of COVID-19: a mathematical modelling study. The Lancet Infectious Diseases,

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -5,7 +5,15 @@
 \title{Calculate the probability a branching process will go extinct based on
 R, k and initial cases}
 \usage{
-probability_extinct(R, k, num_init_infect, ..., offspring_dist)
+probability_extinct(
+  R,
+  k,
+  num_init_infect,
+  ind_control,
+  pop_control,
+  ...,
+  offspring_dist
+)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -15,6 +23,12 @@ per infectious individual).}
 offspring distribution from fitted negative binomial).}
 
 \item{num_init_infect}{A \code{count} specifying the number of initial infections.}
+
+\item{ind_control}{A \code{numeric} specifying the strength of individual-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
+
+\item{pop_control}{A \code{numeric} specifying the strength of population-level
+control measures. Between \code{0} (default) and \code{1} (maximum).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -9,8 +9,8 @@ probability_extinct(
   R,
   k,
   num_init_infect,
-  ind_control,
-  pop_control,
+  ind_control = 0,
+  pop_control = 0,
   ...,
   offspring_dist
 )

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -1,21 +1,67 @@
-test_that("probability_contain works as expected", {
+test_that("probability_contain works as expected for deterministic", {
   prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, control = 0
+    R = 1.5, k = 0.5, num_init_infect = 1
+  )
+  expect_equal(prob_contain, 0.768)
+})
+
+test_that("probability_contain works as expected for stochastic", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 1, stochastic = TRUE
   )
   # larger tolerance for stochastic variance
   expect_equal(prob_contain, 0.7672, tolerance = 1e-2)
 })
 
-test_that("probability_contain works as expected for deterministic", {
+test_that("probability_contain works as expected for population control", {
   prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, control = 0, stochastic = FALSE
+    R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1
   )
-  expect_equal(prob_contain, 0.768)
+  expect_equal(prob_contain, 0.821)
+})
+
+test_that("probability_contain works as expected for individual control", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1
+  )
+  expect_equal(prob_contain, 0.839)
+})
+
+test_that("probability_contain works as expected for stochastic pop control", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1, stochastic = TRUE
+  )
+  expect_equal(prob_contain, 0.819, tolerance = 1e-2)
+})
+
+test_that("probability_contain works as expected for both controls", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1, pop_control = 0.1
+  )
+  expect_equal(prob_contain, 0.892)
+})
+
+test_that("probability_contain works as expected for ind control multi init", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 5, ind_control = 0.1
+  )
+  expect_equal(prob_contain, 0.4157285)
+})
+
+test_that("probability_contain works as expected for pop control multi init", {
+  prob_contain <- probability_contain(
+    R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1,
+  )
+  expect_equal(prob_contain, 0.373006, tolerance = 1e-2)
 })
 
 test_that("probability_contain works as expected for different threshold", {
   prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, control = 0, case_threshold = 50
+    R = 1.5,
+    k = 0.5,
+    num_init_infect = 1,
+    stochastic = TRUE,
+    case_threshold = 50
   )
   # larger tolerance for stochastic variance
   expect_equal(prob_contain, 0.76255, tolerance = 1e-2)
@@ -23,7 +69,11 @@ test_that("probability_contain works as expected for different threshold", {
 
 test_that("probability_contain works as when using dots", {
   prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, control = 0, n = 1e4, infinite = 50
+    R = 1.5,
+    k = 0.5,
+    num_init_infect = 1,
+    n = 1e4,
+    infinite = 50
   )
   # larger tolerance for stochastic variance
   expect_equal(prob_contain, 0.7606, tolerance = 0.1)
@@ -31,28 +81,10 @@ test_that("probability_contain works as when using dots", {
 
 test_that("probability_contain works as when using dots with incorrect name", {
   prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, control = 0, random = 100
+    R = 1.5, k = 0.5, num_init_infect = 1, random = 100
   )
   # larger tolerance for stochastic variance
   expect_equal(prob_contain, 0.76669, tolerance = 1e-2)
-})
-
-test_that("probability_contain fails as expected", {
-  expect_error(
-    probability_contain(R = 1, k = 1, num_init_infect = 2, control = 1),
-    regexp = "(Multiple introductions is not yet implemented)"
-  )
-
-  expect_error(
-    probability_contain(
-      R = 1,
-      k = 1,
-      num_init_infect = 2,
-      control = 1,
-      control_type = "individual"
-    ),
-    regexp = "individual-level controls not yet implemented"
-  )
 })
 
 test_that("probability_contain works with <epidist>", {
@@ -67,17 +99,49 @@ test_that("probability_contain works with <epidist>", {
   expect_equal(
     probability_contain(
       num_init_infect = 1,
-      control = 0.1,
-      stochastic = FALSE,
+      pop_control = 0.1,
       offspring_dist = edist
     ),
     0.904
+  )
+
+  expect_equal(
+    probability_contain(
+      num_init_infect = 1,
+      ind_control = 0.1,
+      offspring_dist = edist
+    ),
+    0.913
+  )
+
+  expect_equal(
+    probability_contain(
+      num_init_infect = 5,
+      ind_control = 0.1,
+      pop_control = 0.1,
+      offspring_dist = edist
+    ),
+    0.71842137
+  )
+})
+
+test_that("probability_contain fails as expected", {
+  expect_error(
+    probability_contain(
+      R = 1,
+      k = 1,
+      num_init_infect = 2,
+      ind_control = 1,
+      stochastic = TRUE
+    ),
+    regexp =
+      "individual-level control not yet implemented for stochastic calculation"
   )
 })
 
 test_that("probability_contain fails without R and k or <epidist>", {
   expect_error(
-    probability_contain(num_init_infect = 1, control = 0.5),
+    probability_contain(num_init_infect = 1, pop_control = 0.5),
     regexp = "One of R and k or <epidist> must be supplied."
   )
 })

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -27,13 +27,44 @@ test_that("probability_epidemic works for k == Inf", {
   )
 })
 
-test_that("probability_epidemic works for different k & a", {
+test_that("probability_epidemic works for different k & num_init_infect", {
   res1 <- probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1)
   res2 <- probability_epidemic(R = 1.5, k = 0.2, num_init_infect = 1)
   res3 <- probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 2)
   res4 <- probability_epidemic(R = 1.5, k = 0.2, num_init_infect = 2)
   expect_true((res2 < res1))
   expect_true((res4 < res3))
+})
+
+test_that("probability_epidemic works with individual-level control", {
+  expect_equal(
+    probability_epidemic(
+      R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.2
+    ),
+    0.091
+  )
+})
+
+test_that("probability_epidemic works with population-level control", {
+  expect_equal(
+    probability_epidemic(
+      R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.2
+    ),
+    0.113
+  )
+})
+
+test_that("probability_epidemic works with both control measures", {
+  expect_equal(
+    probability_epidemic(
+      R = 1.5,
+      k = 0.5,
+      num_init_infect = 1,
+      ind_control = 0.1,
+      pop_control = 0.1
+    ),
+    0.108
+  )
 })
 
 test_that("probability_epidemic fails correctly", {


### PR DESCRIPTION
This PR addresses #13 by implementing a joint framework to infer the effect of individual-level and population-level control measures on the probability that an outbreak will become an epidemic or go extinct. This changes the function signatures of  `probability_epidemic()`, `probability_extinct()` and `probability_contain()`, to include the `pop_control` and `ind_control` arguments. 

`probability_contain()` can now compute the probability of containment for multiple initial infections for both population-level control and individual-level control with the analytical calculation, and for population-level control only for the stochastic calculation. (The function argument default value for `num_init_infect` is now removed as a result).

Function documentation and tests for each of these functions is updated.