### PR TITLE
Add option for `numeric` proportions

### DIFF
--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -18,6 +18,9 @@
 #'
 #' @inheritParams probability_epidemic
 #' @param cluster_size A `number` for the cluster size threshold.
+#' @param format_prop A `logical` determining whether the proportion column
+#' of the `<data.frame>` returned by the function is formatted as a string with
+#' a percentage sign (`%`), (`TRUE`, default), or as a `numeric` (`FALSE`).
 #'
 #' @return A `<data.frame>` with the value for the proportion of new cases
 #' that are part of a transmission event above a threshold for a given value
@@ -37,7 +40,8 @@
 #' # example with a vector of cluster sizes
 #' cluster_size <- c(5, 10, 25)
 #' proportion_cluster_size(R = R, k = k, cluster_size = cluster_size)
-proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist) {
+proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist,
+                                    format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
@@ -53,6 +57,7 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist) {
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)
   checkmate::assert_integerish(cluster_size, lower = 1)
+  checkmate::assert_logical(format_prop, any.missing = FALSE, len = 1)
 
   df <- expand.grid(R, k)
   df <- cbind(df, as.data.frame(matrix(nrow = 1, ncol = length(cluster_size))))
@@ -68,7 +73,9 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist) {
     propn_cluster <- vapply(cluster_size, function(x) {
       sum(simulate_secondary[simulate_secondary >= x]) / sum(simulate_secondary)
     }, FUN.VALUE = numeric(1))
-    propn_cluster <- paste0(round(propn_cluster * 100, digits = 1), "%")
+    if (format_prop) {
+      propn_cluster <- paste0(round(propn_cluster * 100, digits = 1), "%")
+    }
     col <- seq(3, 2 + length(propn_cluster), by = 1)
     df[i, col] <- propn_cluster
   }

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -21,6 +21,7 @@
 #' for which a proportion of cases has produced.
 #' @param sim A `logical` whether the calculation should be done numerically
 #' (i.e. simulate secondary contacts) or analytically.
+#' @inheritParams proportion_cluster_size
 #'
 #' @return A `<data.frame>` with the value for the proportion of cases for a
 #' given value of R and k.
@@ -65,7 +66,8 @@ proportion_transmission <- function(R, k,
                                     percent_transmission,
                                     sim = FALSE,
                                     ...,
-                                    offspring_dist) {
+                                    offspring_dist,
+                                    format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
     stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
@@ -82,6 +84,7 @@ proportion_transmission <- function(R, k,
   checkmate::assert_numeric(k, lower = 0)
   checkmate::assert_number(percent_transmission, lower = 0, upper = 1)
   checkmate::assert_logical(sim, any.missing = FALSE, len = 1)
+  checkmate::assert_logical(format_prop, any.missing = FALSE, len = 1)
 
   df <- expand.grid(R = R, k = k, NA_real_)
   colnames(df) <- c("R", "k", paste0("prop_", percent_transmission * 100))
@@ -101,8 +104,11 @@ proportion_transmission <- function(R, k,
       )
     }
 
+    if (format_prop) {
+      prop <- paste0(round(prop * 100, digits = 1), "%")
+    }
     # df is ways i x 3 so insert value into col 3
-    df[i, 3] <- paste0(round(prop * 100, digits = 1), "%")
+    df[i, 3] <- prop
   }
   return(df)
 }

--- a/man/proportion_cluster_size.Rd
+++ b/man/proportion_cluster_size.Rd
@@ -6,7 +6,14 @@
 given size (useful to inform backwards contact tracing efforts, i.e. how
 many cases are associated with large clusters)}
 \usage{
-proportion_cluster_size(R, k, cluster_size, ..., offspring_dist)
+proportion_cluster_size(
+  R,
+  k,
+  cluster_size,
+  ...,
+  offspring_dist,
+  format_prop = TRUE
+)
 }
 \arguments{
 \item{R}{A \code{number} specifying the R parameter (i.e. average secondary cases
@@ -21,6 +28,10 @@ offspring distribution from fitted negative binomial).}
 
 \item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+
+\item{format_prop}{A \code{logical} determining whether the proportion column
+of the \verb{<data.frame>} returned by the function is formatted as a string with
+a percentage sign (\verb{\%}), (\code{TRUE}, default), or as a \code{numeric} (\code{FALSE}).}
 }
 \value{
 A \verb{<data.frame>} with the value for the proportion of new cases

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -11,7 +11,8 @@ proportion_transmission(
   percent_transmission,
   sim = FALSE,
   ...,
-  offspring_dist
+  offspring_dist,
+  format_prop = TRUE
 )
 }
 \arguments{
@@ -31,6 +32,10 @@ for which a proportion of cases has produced.}
 
 \item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
 epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+
+\item{format_prop}{A \code{logical} determining whether the proportion column
+of the \verb{<data.frame>} returned by the function is formatted as a string with
+a percentage sign (\verb{\%}), (\code{TRUE}, default), or as a \code{numeric} (\code{FALSE}).}
 }
 \value{
 A \verb{<data.frame>} with the value for the proportion of cases for a

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -54,6 +54,22 @@ test_that("proportion_cluster_size works as expected for multiple R & k & cs", {
   )
 })
 
+test_that("proportion_cluster_size works as expected for format_prop = FALSE", {
+  res <- proportion_cluster_size(
+    R = c(1, 2, 3),
+    k = c(0.1, 0.2, 0.3),
+    cluster_size = c(5, 10, 25),
+    format_prop = FALSE
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_identical(dim(res), c(9L, 5L))
+  expect_identical(
+    unname(vapply(res, class, FUN.VALUE = character(1))),
+    rep("numeric", 5)
+  )
+})
+
 test_that("proportion_cluster_size fails as expected", {
   expect_error(
     proportion_cluster_size(R = "1", k = 0.1, cluster_size = 5),

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -81,6 +81,22 @@ test_that("proportion_transmission works as expected for multiple R & k", {
   )
 })
 
+test_that("proportion_transmission works as expected for format_prop = FALSE", {
+  res <- proportion_transmission(
+    R = c(1, 2, 3),
+    k = c(0.1, 0.2, 0.3),
+    percent_transmission = 0.8,
+    format_prop = FALSE
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_identical(dim(res), c(9L, 3L))
+  expect_identical(
+    unname(vapply(res, class, character(1))),
+    rep("numeric", 3)
+  )
+})
+
 test_that("proportion_transmission fails as expected", {
   expect_error(
     proportion_transmission(R = "1", k = 0.1, percent_transmission = 0.8),

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -34,7 +34,7 @@ The distribution functions return a vector of `numeric`s of equal length to the 
 
 ## Design decisions
 
-- `proportion_*()` functions return a `<data.frame>` with the proportion column(s) containing `character` strings, formatted with a percentage sign (`%`). It was reasoned that {superspreading} is most likely used either as a stand-alone package, or at the terminus of a epidemiological analysis pipeline, and thus the outputs of {superspreading} functions would not be passed into other functions. If this were the case then the proportions would be better as `numeric`.
+- `proportion_*()` functions return a `<data.frame>` with the proportion column(s) containing `character` strings, formatted with a percentage sign (`%`) by default. It was reasoned that {superspreading} is most likely used either as a stand-alone package, or at the terminus of a epidemiological analysis pipeline, and thus the outputs of {superspreading} functions would not be passed into other functions. For instances where these proportions need to be passed to another calculation or for plotting purposes the `format_prop` argument can be switched to `FALSE` and a `numeric` column of proportions will be returned.
 
 - The distribution functions are vectorised (i.e. wrapped in `Vectorize()`). This enables them to be used identically to base R distribution functions.
 


### PR DESCRIPTION
This PR addresses #69 by adding a new argument to `proportion_*()` functions: `format_prop`. The default behaviour of the function remains the same, formatting the proportions returned in the `<data.frame>` (`format_prop = TRUE`), but this argument now allows users to turn off the formatting (`format_prop = FALSE`) and the proportions column(s) of the output `<data.frame>` will be `numeric`.

The design principles vignette is updated explaining the thought behind the added flexibility of output types.

Tests have been added to check the new functionality and the function documentation is also updated.