### PR TITLE
Update `probability_contain` in Epidemic Risk vignette

### DIFF
--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -306,10 +306,7 @@ prob_contain <- apply(contain_params, 1, function(x) {
     R = x[["R"]],
     k = x[["k"]],
     num_init_infect = x[["num_init_infect"]],
-    control = x[["control"]],
-    control_type = "population",
-    stochastic = TRUE,
-    case_threshold = 100
+    pop_control = x[["control"]]
   )
 })
 contain_params <- cbind(contain_params, prob_contain)


### PR DESCRIPTION
This PR fixes the probability of containment calculation (`probability_contain()`) in the Epidemic Risk vignette (`epidemic_risk.Rmd`). Since #70 the last plot in `epidemic_risk.Rmd` was not correct as the arguments were not updated and the old arguments were being silently swallowed by `...`. This is now fixed. 

Additionally, the calculation has switched from using the numerical/simulated calculation to the analytical one. This both improves the speed of the vignette rendering, and moves in the general direction of preferring analytical versus numerical calculations for {superspreading}.