### PR TITLE
Run testing suite sequentially

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Remotes:
     epiverse-trace/epiparameter,
     epiverse-trace/bpmodels
 Config/testthat/edition: 3
-Config/testthat/parallel: true
 Config/Needs/website:
     epiverse-trace/epiversetheme
 VignetteBuilder: knitr


### PR DESCRIPTION
This removes `Config/testthat/parallel: true` from the `DESCRIPTION` as running the tests locally in parallel causes Rplots.pdf to be produced as a side-effect.