### PR TITLE
Update `proportion_*()` functions

### DIFF
--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -70,8 +70,8 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist,
       size = df[i, "k"]
     )
     propn_cluster <- vapply(cluster_size, function(x) {
-      sum(simulate_secondary[simulate_secondary >= x]) / sum(simulate_secondary)
-    }, FUN.VALUE = numeric(1))
+      sum(simulate_secondary[simulate_secondary >= x])
+    }, FUN.VALUE = numeric(1)) / sum(simulate_secondary)
     if (format_prop) {
       propn_cluster <- paste0(round(propn_cluster * 100, digits = 1), "%")
     }

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -1,15 +1,14 @@
-#' Proportion of new cases that originated with a transmission event of a
-#' given size (useful to inform backwards contact tracing efforts, i.e. how
-#' many cases are associated with large clusters)
+#' Estimate what proportion of new cases originated within a transmission
+#' event of a given size
 #'
 #' @description Calculates the proportion of new cases that originated with a
-#' transmission event of a given size (useful to inform backwards contact
-#' tracing efforts, i.e. how many cases are associated with large clusters).
-#' Here we define a cluster to as a transmission of a primary case
+#' transmission event of a given size. It can be useful to inform backwards
+#' contact tracing efforts, i.e. how many cases are associated with large
+#' clusters. Here we define a cluster to as a transmission of a primary case
 #' to at least one secondary case.
 #'
 #' @details This function calculates the proportion of secondary cases that
-#' are caused transmission events of a certain size. It does not calculate
+#' are caused by transmission events of a certain size. It does not calculate
 #' the proportion of transmission events that cause a cluster of secondary
 #' cases of a certain size. In other words it is the number of cases above a
 #' threshold divided by the total number of cases, not the number of

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -1,4 +1,4 @@
-#' Estimate what proportion of cases that cause a certain proportion of
+#' Estimate what proportion of cases cause a certain proportion of
 #' transmission
 #'
 #' @description Calculates the proportion of cases that cause a certain

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -19,7 +19,7 @@
 #' @inheritParams probability_epidemic
 #' @param percent_transmission A `number` of the percentage transmission
 #' for which a proportion of cases has produced.
-#' @param sim A `logical` whether the calculation should be done numerically
+#' @param simulate A `logical` whether the calculation should be done numerically
 #' (i.e. simulate secondary contacts) or analytically.
 #' @inheritParams proportion_cluster_size
 #'
@@ -64,7 +64,7 @@
 #' )
 proportion_transmission <- function(R, k,
                                     percent_transmission,
-                                    sim = FALSE,
+                                    simulate = FALSE,
                                     ...,
                                     offspring_dist,
                                     format_prop = TRUE) {
@@ -83,14 +83,14 @@ proportion_transmission <- function(R, k,
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)
   checkmate::assert_number(percent_transmission, lower = 0, upper = 1)
-  checkmate::assert_logical(sim, any.missing = FALSE, len = 1)
+  checkmate::assert_logical(simulate, any.missing = FALSE, len = 1)
   checkmate::assert_logical(format_prop, any.missing = FALSE, len = 1)
 
   df <- expand.grid(R = R, k = k, NA_real_)
   colnames(df) <- c("R", "k", paste0("prop_", percent_transmission * 100))
 
   for (i in seq_len(nrow(df))) {
-    if (sim) {
+    if (simulate) {
       prop <- .prop_transmission_numerical(
         R = df[i, "R"],
         k = df[i, "k"],

--- a/man/proportion_cluster_size.Rd
+++ b/man/proportion_cluster_size.Rd
@@ -2,9 +2,8 @@
 % Please edit documentation in R/proportion_cluster_size.R
 \name{proportion_cluster_size}
 \alias{proportion_cluster_size}
-\title{Proportion of new cases that originated with a transmission event of a
-given size (useful to inform backwards contact tracing efforts, i.e. how
-many cases are associated with large clusters)}
+\title{Estimate what proportion of new cases originated within a transmission
+event of a given size}
 \usage{
 proportion_cluster_size(
   R,
@@ -40,14 +39,14 @@ of R and k.
 }
 \description{
 Calculates the proportion of new cases that originated with a
-transmission event of a given size (useful to inform backwards contact
-tracing efforts, i.e. how many cases are associated with large clusters).
-Here we define a cluster to as a transmission of a primary case
+transmission event of a given size. It can be useful to inform backwards
+contact tracing efforts, i.e. how many cases are associated with large
+clusters. Here we define a cluster to as a transmission of a primary case
 to at least one secondary case.
 }
 \details{
 This function calculates the proportion of secondary cases that
-are caused transmission events of a certain size. It does not calculate
+are caused by transmission events of a certain size. It does not calculate
 the proportion of transmission events that cause a cluster of secondary
 cases of a certain size. In other words it is the number of cases above a
 threshold divided by the total number of cases, not the number of

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -9,7 +9,7 @@ proportion_transmission(
   R,
   k,
   percent_transmission,
-  sim = FALSE,
+  simulate = FALSE,
   ...,
   offspring_dist,
   format_prop = TRUE
@@ -25,7 +25,7 @@ offspring distribution from fitted negative binomial).}
 \item{percent_transmission}{A \code{number} of the percentage transmission
 for which a proportion of cases has produced.}
 
-\item{sim}{A \code{logical} whether the calculation should be done numerically
+\item{simulate}{A \code{logical} whether the calculation should be done numerically
 (i.e. simulate secondary contacts) or analytically.}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/proportion_transmission.R
 \name{proportion_transmission}
 \alias{proportion_transmission}
-\title{Estimate what proportion of cases that cause a certain proportion of
+\title{Estimate what proportion of cases cause a certain proportion of
 transmission}
 \usage{
 proportion_transmission(

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -12,7 +12,7 @@ test_that("proportion_transmission works as expected for single R and k", {
     R = 2,
     k = 0.5,
     percent_transmission = 0.8,
-    sim = TRUE
+    simulate = TRUE
   )
 
   expect_s3_class(res, "data.frame")
@@ -41,7 +41,7 @@ test_that("proportion_transmission works as expected for multiple R", {
     R = c(1, 2, 3),
     k = 0.5,
     percent_transmission = 0.8,
-    sim = TRUE
+    simulate = TRUE
   )
 
   expect_s3_class(res, "data.frame")
@@ -70,7 +70,7 @@ test_that("proportion_transmission works as expected for multiple R & k", {
     R = c(1, 2, 3),
     k = c(0.1, 0.2, 0.3),
     percent_transmission = 0.8,
-    sim = TRUE
+    simulate = TRUE
   )
 
   expect_s3_class(res, "data.frame")
@@ -118,9 +118,9 @@ test_that("proportion_transmission fails as expected", {
       R = 1,
       k = 0.1,
       percent_transmission = 0.8,
-      sim = 1
+      simulate = 1
     ),
-    regexp = "Assertion on 'sim' failed"
+    regexp = "Assertion on 'simulate' failed"
   )
 })
 


### PR DESCRIPTION
This PR updates the `proportion_*()` functions (`proportion_transmission()` & `proportion_cluster_size()`) from comments from the package review #75. The function documentation is updated, an argument is renamed and there is a small performance improvement in `proportion_cluster_size()`. 