### PR TITLE
Update `calc_network_R()`

### DIFF
--- a/R/calc_network_R.R
+++ b/R/calc_network_R.R
@@ -12,7 +12,7 @@
 #' @param prob_transmission A `numeric` probability of transmission per contact,
 #' also known as \eqn{\beta}.
 #' @param age_range A `numeric` vector with two elements, the lower and upper
-#' age limits of individuals in the network. Default is 16 - 74 (`c(16, 74)`).
+#' age limits of individuals in the network.
 #'
 #' @return A named `numeric` vector of length 2, the unadjusted (`R`)
 #' and corrected (`R_var`) estimates of \eqn{R}.
@@ -31,7 +31,7 @@ calc_network_R <- function(mean_num_contact,
                            sd_num_contact,
                            infect_duration,
                            prob_transmission,
-                           age_range = c(16, 74)) {
+                           age_range) {
   checkmate::assert_number(mean_num_contact, lower = 0, finite = TRUE)
   checkmate::assert_number(sd_num_contact, lower = 0, finite = TRUE)
   checkmate::assert_number(infect_duration, lower = 0, finite = TRUE)

--- a/R/calc_network_R.R
+++ b/R/calc_network_R.R
@@ -15,7 +15,7 @@
 #' age limits of individuals in the network.
 #'
 #' @return A named `numeric` vector of length 2, the unadjusted (`R`)
-#' and corrected (`R_var`) estimates of \eqn{R}.
+#' and network adjusted (`R_net`) estimates of \eqn{R}.
 #' @export
 #'
 #' @examples
@@ -51,10 +51,10 @@ calc_network_R <- function(mean_num_contact,
 
   # calculate R0 with and without correction
   R <- beta * contacts_per_time[["mean"]] * infect_duration
-  R_var <- beta * infect_duration *
+  R_net <- beta * infect_duration *
     (contacts_per_time[["mean"]] + contacts_per_time[["var"]] /
       contacts_per_time[["mean"]])
 
   # return R0 with and without variance correction
-  c(R = R, R_var = R_var)
+  c(R = R, R_net = R_net)
 }

--- a/R/calc_network_R.R
+++ b/R/calc_network_R.R
@@ -2,8 +2,7 @@
 #' network
 #'
 #' @description The calculation of the reproduction number adjusting for
-#' heterogeneity in number of contacts. The output of the function returns the
-#' unadjusted (`R`) and corrected (`R_var`) estimates of \eqn{R}.
+#' heterogeneity in number of contacts.
 #'
 #' @param mean_num_contact A `numeric`, mean (average) number of new contacts
 #' per unit time.
@@ -15,7 +14,8 @@
 #' @param age_range A `numeric` vector with two elements, the lower and upper
 #' age limits of individuals in the network. Default is 16 - 74 (`c(16, 74)`).
 #'
-#' @return A named `numeric` vector of length 2.
+#' @return A named `numeric` vector of length 2, the unadjusted (`R`)
+#' and corrected (`R_var`) estimates of \eqn{R}.
 #' @export
 #'
 #' @examples

--- a/R/calc_network_R.R
+++ b/R/calc_network_R.R
@@ -38,11 +38,11 @@ calc_network_R <- function(mean_num_contact,
   checkmate::assert_number(prob_transmission, lower = 0, finite = TRUE)
   checkmate::assert_numeric(age_range, len = 2, lower = 0, finite = TRUE)
 
-  # define measured sexual contacts
-  # normalise by years sexually active
+  # define measured contacts (e.g. sexual contacts)
+  # normalise by time active in the network (e.g. sexually active)
   scale_by_active <- 1 / (max(age_range) - min(age_range))
-  # calculate new partners per year
-  contacts_per_year <- c(
+  # calculate new partners per time
+  contacts_per_time <- c(
     mean = mean_num_contact * scale_by_active,
     var = sd_num_contact^2 * scale_by_active^2
   )
@@ -50,10 +50,10 @@ calc_network_R <- function(mean_num_contact,
   beta <- prob_transmission
 
   # calculate R0 with and without correction
-  R <- beta * contacts_per_year[["mean"]] * infect_duration
+  R <- beta * contacts_per_time[["mean"]] * infect_duration
   R_var <- beta * infect_duration *
-    (contacts_per_year[["mean"]] + contacts_per_year[["var"]] /
-      contacts_per_year[["mean"]])
+    (contacts_per_time[["mean"]] + contacts_per_time[["var"]] /
+      contacts_per_time[["mean"]])
 
   # return R0 with and without variance correction
   c(R = R, R_var = R_var)

--- a/man/calc_network_R.Rd
+++ b/man/calc_network_R.Rd
@@ -10,7 +10,7 @@ calc_network_R(
   sd_num_contact,
   infect_duration,
   prob_transmission,
-  age_range = c(16, 74)
+  age_range
 )
 }
 \arguments{
@@ -26,7 +26,7 @@ contacts per unit time.}
 also known as \eqn{\beta}.}
 
 \item{age_range}{A \code{numeric} vector with two elements, the lower and upper
-age limits of individuals in the network. Default is 16 - 74 (\code{c(16, 74)}).}
+age limits of individuals in the network.}
 }
 \value{
 A named \code{numeric} vector of length 2, the unadjusted (\code{R})

--- a/man/calc_network_R.Rd
+++ b/man/calc_network_R.Rd
@@ -29,12 +29,12 @@ also known as \eqn{\beta}.}
 age limits of individuals in the network. Default is 16 - 74 (\code{c(16, 74)}).}
 }
 \value{
-A named \code{numeric} vector of length 2.
+A named \code{numeric} vector of length 2, the unadjusted (\code{R})
+and corrected (\code{R_var}) estimates of \eqn{R}.
 }
 \description{
 The calculation of the reproduction number adjusting for
-heterogeneity in number of contacts. The output of the function returns the
-unadjusted (\code{R}) and corrected (\code{R_var}) estimates of \eqn{R}.
+heterogeneity in number of contacts.
 }
 \examples{
 # example using NATSAL data

--- a/man/calc_network_R.Rd
+++ b/man/calc_network_R.Rd
@@ -30,7 +30,7 @@ age limits of individuals in the network.}
 }
 \value{
 A named \code{numeric} vector of length 2, the unadjusted (\code{R})
-and corrected (\code{R_var}) estimates of \eqn{R}.
+and network adjusted (\code{R_net}) estimates of \eqn{R}.
 }
 \description{
 The calculation of the reproduction number adjusting for

--- a/tests/testthat/test-calc_network_R.R
+++ b/tests/testthat/test-calc_network_R.R
@@ -6,7 +6,7 @@ test_that("calc_network_R works as expected", {
     prob_transmission = 1,
     age_range = c(15, 75)
   )
-  expect_equal(R, c(R = 0.25, R_var = 3.0277778))
+  expect_equal(R, c(R = 0.25, R_net = 3.0277778))
 })
 
 test_that("calc_network_R gives equal values when sd is zero", {
@@ -17,6 +17,6 @@ test_that("calc_network_R gives equal values when sd is zero", {
     prob_transmission = 1,
     age_range = c(15, 75)
   )
-  expect_equal(R, c(R = 0.25, R_var = 0.25))
+  expect_equal(R, c(R = 0.25, R_net = 0.25))
 })
 

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -71,10 +71,10 @@ R <- t(apply(
 res <- cbind(params, R)
 res <- reshape(
   data = res,
-  varying = c("R", "R_var"),
+  varying = c("R", "R_net"),
   v.names = "R",
   direction = "long",
-  times = c("R", "R_var"),
+  times = c("R", "R_net"),
   timevar = "group"
 )
 ```
@@ -107,7 +107,7 @@ ggplot(data = res) +
   ) +
   facet_wrap(
     vars(group),
-    labeller = as_labeller(c(R = "R", R_var = "Adjusted R"))
+    labeller = as_labeller(c(R = "R", R_net = "Adjusted R"))
   ) +
   scale_fill_viridis_c(
     trans = "log",
@@ -136,10 +136,10 @@ res <- do.call(rbind, res)
 res <- as.data.frame(cbind(beta, res))
 res <- reshape(
   data = res,
-  varying = c("R", "R_var"),
+  varying = c("R", "R_net"),
   v.names = "R",
   direction = "long",
-  times = c("R", "R_var"),
+  times = c("R", "R_net"),
   timevar = "group"
 )
 ```


### PR DESCRIPTION
This PR updates `calc_network_R()` given comments from #77. The function documentation has been updated, the comments within the function are generalised, the default for the `age_range` argument is removed and the output vector is renamed to `c(R, R_net)` from `c(R, R_var)`.