### PR TITLE
Update package testing

### DIFF
--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -50,7 +50,7 @@ probability_contain <- function(R,
                                 offspring_dist) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
   }
   # check inputs
   if (input_params) {

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -89,7 +89,7 @@ probability_extinct <- function(R,
                                 offspring_dist) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -44,7 +44,7 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist,
                                     format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -70,7 +70,7 @@ proportion_transmission <- function(R, k,
                                     format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("One of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
   }
 
   # check inputs

--- a/tests/testthat/_snaps/calc_network_R.md
+++ b/tests/testthat/_snaps/calc_network_R.md
@@ -1,0 +1,9 @@
+# calc_network_R works as expected
+
+    Code
+      calc_network_R(mean_num_contact = 15, sd_num_contact = 50, infect_duration = 0.5,
+        prob_transmission = 1, age_range = c(15, 75))
+    Output
+             R    R_net 
+      0.125000 1.513889 
+

--- a/tests/testthat/_snaps/offspring_distributions.md
+++ b/tests/testthat/_snaps/offspring_distributions.md
@@ -1,0 +1,60 @@
+# dpoislnorm works as expected
+
+    Code
+      dpoislnorm(x = 1, meanlog = 1, sdlog = 1)
+    Output
+      [1] 0.1757334
+
+---
+
+    Code
+      dpoislnorm(x = 1:10, meanlog = 1, sdlog = 1)
+    Output
+       [1] 0.17573342 0.14691182 0.11325601 0.08550612 0.06458689 0.04920390
+       [7] 0.03791369 0.02956797 0.02333243 0.01861790
+
+# ppoislnorm works as expected
+
+    Code
+      ppoislnorm(q = 1, meanlog = 1, sdlog = 1)
+    Output
+      [1] 0.3327376
+
+---
+
+    Code
+      ppoislnorm(q = 1:10, meanlog = 1, sdlog = 1)
+    Output
+       [1] 0.3327376 0.4796494 0.5929054 0.6784115 0.7429984 0.7922023 0.8301160
+       [8] 0.8596840 0.8830164 0.9016343
+
+# dpisweibull works as expected
+
+    Code
+      dpoisweibull(x = 1, shape = 1, scale = 1)
+    Output
+      [1] 0.25
+
+---
+
+    Code
+      dpoisweibull(x = 1:10, shape = 1, scale = 1)
+    Output
+       [1] 0.2500000000 0.1250000000 0.0625000001 0.0312500000 0.0156250000
+       [6] 0.0078125000 0.0039062500 0.0019531250 0.0009765625 0.0004882813
+
+# ppoisweibull works as expected
+
+    Code
+      ppoisweibull(q = 1, shape = 1, scale = 1)
+    Output
+      [1] 0.75
+
+---
+
+    Code
+      ppoisweibull(q = 1:10, shape = 1, scale = 1)
+    Output
+       [1] 0.7500000 0.8750000 0.9375000 0.9687500 0.9843750 0.9921875 0.9960937
+       [8] 0.9980469 0.9990234 0.9995117
+

--- a/tests/testthat/_snaps/probability_contain.md
+++ b/tests/testthat/_snaps/probability_contain.md
@@ -1,0 +1,105 @@
+# probability_contain works as expected for deterministic
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 1)
+    Output
+      [1] 0.7675919
+
+# probability_contain works as expected for stochastic
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.76625]
+    }
+
+# probability_contain works as expected for population control
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1)
+    Output
+      [1] 0.8213172
+
+# probability_contain works as expected for individual control
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1)
+    Output
+      [1] 0.8391855
+
+# probability_contain works as expected for stochastic pop control
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.81856]
+    }
+
+# probability_contain works as expected for both controls
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1,
+        pop_control = 0.1)
+    Output
+      [1] 0.8915076
+
+# probability_contain works as expected for ind control multi init
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 5, ind_control = 0.1)
+    Output
+      [1] 0.4161882
+
+# probability_contain works as expected for pop control multi init
+
+    Code
+      probability_contain(R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1, )
+    Output
+      [1] 0.3737271
+
+# probability_contain works as expected for different threshold
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.76148]
+    }
+
+# probability_contain works as when using dots
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.7636]
+    }
+
+# probability_contain works as when using dots with incorrect name
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.76759189]
+    }
+
+# probability_contain works with <epidist>
+
+    Code
+      probability_contain(num_init_infect = 1, pop_control = 0.1, offspring_dist = edist)
+    Output
+      [1] 0.9037105
+
+---
+
+    Code
+      probability_contain(num_init_infect = 1, ind_control = 0.1, offspring_dist = edist)
+    Output
+      [1] 0.9133394
+
+---
+
+    Code
+      probability_contain(num_init_infect = 5, ind_control = 0.1, pop_control = 0.1,
+        offspring_dist = edist)
+    Output
+      [1] 0.7168911
+

--- a/tests/testthat/_snaps/probability_epidemic.md
+++ b/tests/testthat/_snaps/probability_epidemic.md
@@ -1,0 +1,66 @@
+# probability_epidemic works for R > 1
+
+    Code
+      probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1)
+    Output
+      [1] 0.2324081
+
+---
+
+    Code
+      probability_extinct(R = 1.5, k = 0.5, num_init_infect = 1)
+    Output
+      [1] 0.7675919
+
+# probability_epidemic works for k == Inf
+
+    Code
+      probability_epidemic(R = 1.5, k = Inf, num_init_infect = 1)
+    Output
+      [1] 0.5828111
+
+# probability_epidemic works with individual-level control
+
+    Code
+      probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.2)
+    Output
+      [1] 0.09070598
+
+# probability_epidemic works with population-level control
+
+    Code
+      probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.2)
+    Output
+      [1] 0.1133825
+
+# probability_epidemic works with both control measures
+
+    Code
+      probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1,
+        pop_control = 0.1)
+    Output
+      [1] 0.1084924
+
+# probability_epidemic works with <epidist>
+
+    Code
+      probability_epidemic(num_init_infect = 1, offspring_dist = edist)
+    Output
+      [1] 0.1198705
+
+# probability_epidemic works with grid
+
+    Code
+      probability_epidemic(R = 1.5, k = 1, num_init_infect = 5, ind_control = 0.1,
+        pop_control = 0.1, fit_method = "grid")
+    Output
+      [1] 0.5792928
+
+# probability_epidemic works with spliced list
+
+    Code
+      probability_epidemic(R = 1.5, k = 1, num_init_infect = 5, ind_control = 0.1,
+        pop_control = 0.1, !!!list(fit_method = "grid"))
+    Output
+      [1] 0.5792928
+

--- a/tests/testthat/_snaps/proportion_cluster_size.md
+++ b/tests/testthat/_snaps/proportion_cluster_size.md
@@ -1,0 +1,50 @@
+# proportion_cluster_size works as expected for format_prop = FALSE
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["R", "k", "prop_5", "prop_10", "prop_25"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1, 2, 3, 1, 2, 3, 1, 2, 3]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.72803077, 0.8532689, 0.90322752, 0.56891711, 0.76277228, 0.84059606, 0.46297561, 0.69320137, 0.79201115]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.46999814, 0.68956284, 0.78628927, 0.25105412, 0.51202964, 0.64976405, 0.14601832, 0.39340829, 0.54954862]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.1172671, 0.35034513, 0.50350702, 0.01801677, 0.1401319, 0.27360663, 0.00361606, 0.05595971, 0.16017042]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/proportion_transmission.md
+++ b/tests/testthat/_snaps/proportion_transmission.md
@@ -1,0 +1,75 @@
+# proportion_transmission works as expected for single R and k
+
+    Code
+      proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.8)
+    Output
+        R   k prop_80
+      1 2 0.5   26.4%
+
+# proportion_transmission works as expected for multiple R
+
+    Code
+      proportion_transmission(R = c(1, 2, 3), k = 0.5, percent_transmission = 0.8)
+    Output
+        R   k prop_80
+      1 1 0.5   22.6%
+      2 2 0.5   26.4%
+      3 3 0.5     28%
+
+# proportion_transmission works as expected for multiple R & k
+
+    Code
+      proportion_transmission(R = c(1, 2, 3), k = c(0.1, 0.2, 0.3),
+      percent_transmission = 0.8)
+    Output
+        R   k prop_80
+      1 1 0.1    8.7%
+      2 2 0.1    9.2%
+      3 3 0.1    9.4%
+      4 1 0.2   14.3%
+      5 2 0.2   15.6%
+      6 3 0.2     16%
+      7 1 0.3   18.2%
+      8 2 0.3   20.3%
+      9 3 0.3     21%
+
+# proportion_transmission works as expected for format_prop = FALSE
+
+    Code
+      proportion_transmission(R = c(1, 2, 3), k = c(0.1, 0.2, 0.3),
+      percent_transmission = 0.8, format_prop = FALSE)
+    Output
+        R   k    prop_80
+      1 1 0.1 0.08693433
+      2 2 0.1 0.09208820
+      3 3 0.1 0.09389299
+      4 1 0.2 0.14293729
+      5 2 0.2 0.15561248
+      6 3 0.2 0.16024765
+      7 1 0.3 0.18158065
+      8 2 0.3 0.20282175
+      9 3 0.3 0.21039108
+
+# .prop_transmission_numerical works as expected
+
+    {
+      "type": "double",
+      "attributes": {},
+      "value": [0.26347]
+    }
+
+# .prop_transmission_analytical works as expected
+
+    Code
+      .prop_transmission_analytical(R = 2, k = 0.5, percent_transmission = 0.8)
+    Output
+      [1] 0.264419
+
+# proportion_transmission works with <epidist>
+
+    Code
+      proportion_transmission(percent_transmission = 0.8, offspring_dist = edist)
+    Output
+           R    k prop_80
+      1 1.63 0.16     13%
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,42 @@
+# ic_tbl works as expected
+
+    Code
+      ic_tbl(pois_fit, geom_fit, nbinom_fit)
+    Output
+        distribution       AIC   DeltaAIC          wAIC       BIC   DeltaBIC
+      1       nbinom  568.1201   0.000000  9.903974e-01  573.3305   0.000000
+      2         geom  577.3923   9.272144  9.602603e-03  579.9974   6.666974
+      3         pois 1139.2737 571.153624 9.362155e-125 1141.8789 568.548454
+                 wBIC
+      1  9.655599e-01
+      2  3.444009e-02
+      3 3.357771e-124
+
+# ic_tbl works as expected with sort_by = BIC
+
+    Code
+      ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "BIC")
+    Output
+        distribution       AIC   DeltaAIC          wAIC       BIC   DeltaBIC
+      1       nbinom  568.1201   0.000000  9.903974e-01  573.3305   0.000000
+      2         geom  577.3923   9.272144  9.602603e-03  579.9974   6.666974
+      3         pois 1139.2737 571.153624 9.362155e-125 1141.8789 568.548454
+                 wBIC
+      1  9.655599e-01
+      2  3.444009e-02
+      3 3.357771e-124
+
+# ic_tbl works as expected with sort_by = none
+
+    Code
+      ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "none")
+    Output
+        distribution       AIC   DeltaAIC          wAIC       BIC   DeltaBIC
+      1         pois 1139.2737 571.153624 9.362155e-125 1141.8789 568.548454
+      2         geom  577.3923   9.272144  9.602603e-03  579.9974   6.666974
+      3       nbinom  568.1201   0.000000  9.903974e-01  573.3305   0.000000
+                 wBIC
+      1 3.357771e-124
+      2  3.444009e-02
+      3  9.655599e-01
+

--- a/tests/testthat/test-calc_network_R.R
+++ b/tests/testthat/test-calc_network_R.R
@@ -1,12 +1,14 @@
 test_that("calc_network_R works as expected", {
-  R <- calc_network_R(
-    mean_num_contact = 15,
-    sd_num_contact = 50,
-    infect_duration = 1,
-    prob_transmission = 1,
-    age_range = c(15, 75)
+  expect_snapshot(
+    calc_network_R(
+      mean_num_contact = 15,
+      sd_num_contact = 50,
+      infect_duration = 0.5,
+      prob_transmission = 1,
+      age_range = c(15, 75)
+    )
   )
-  expect_equal(R, c(R = 0.25, R_net = 3.0277778))
+
 })
 
 test_that("calc_network_R gives equal values when sd is zero", {

--- a/tests/testthat/test-offspring_distributions.R
+++ b/tests/testthat/test-offspring_distributions.R
@@ -1,50 +1,24 @@
 test_that("dpoislnorm works as expected", {
-  expect_equal(dpoislnorm(x = 1, meanlog = 1, sdlog = 1), 0.1757334228)
-  expect_equal(
-    dpoislnorm(x = 1:10, meanlog = 1, sdlog = 1),
-    c(
-      0.17573342280, 0.14691182498, 0.11325600664, 0.08550611509,
-      0.06458689240, 0.04920389792, 0.03791369334, 0.02956797114,
-      0.02333243044, 0.01861789729
-    )
-  )
+  expect_snapshot(dpoislnorm(x = 1, meanlog = 1, sdlog = 1))
+  expect_snapshot(dpoislnorm(x = 1:10, meanlog = 1, sdlog = 1))
 })
 
 test_that("ppoislnorm works as expected", {
-  expect_equal(ppoislnorm(q = 1, meanlog = 1, sdlog = 1), 0.332737598)
-  expect_equal(
-    ppoislnorm(q = 1:10, meanlog = 1, sdlog = 1),
-    c(
-      0.3327375980, 0.4796494230, 0.5929054296, 0.6784115447, 0.7429984371,
-      0.7922023350, 0.8301160284, 0.8596839995, 0.8830164300, 0.9016343273
-    )
-  )
+  expect_snapshot(ppoislnorm(q = 1, meanlog = 1, sdlog = 1))
+  expect_snapshot(ppoislnorm(q = 1:10, meanlog = 1, sdlog = 1))
   expect_true(is.nan(ppoislnorm(q = NaN, meanlog = 1, sdlog = 1)))
   expect_true(is.na(ppoislnorm(q = NA, meanlog = 1, sdlog = 1)))
   expect_identical(unname(ppoislnorm(q = "1", meanlog = 1, sdlog = 1)), 0)
 })
 
 test_that("dpisweibull works as expected", {
-  expect_equal(dpoisweibull(x = 1, shape = 1, scale = 1), 0.25)
-  expect_equal(
-    dpoisweibull(x = 1:10, shape = 1, scale = 1),
-    c(
-      0.2499999999994, 0.1250000000315, 0.0625000001326, 0.0312500000001,
-      0.0156250000000, 0.0078124999997, 0.0039062500000, 0.0019531250000,
-      0.0009765625000, 0.0004882812527
-    )
-  )
+  expect_snapshot(dpoisweibull(x = 1, shape = 1, scale = 1))
+  expect_snapshot(dpoisweibull(x = 1:10, shape = 1, scale = 1))
 })
 
 test_that("ppoisweibull works as expected", {
-  expect_equal(ppoisweibull(q = 1, shape = 1, scale = 1), 0.7499999996)
-  expect_equal(
-    ppoisweibull(q = 1:10, shape = 1, scale = 1),
-    c(
-      0.7499999996, 0.8749999996, 0.9374999998, 0.9687499998, 0.9843749998,
-      0.9921874998, 0.9960937498, 0.9980468748, 0.9990234373, 0.9995117185
-    )
-  )
+  expect_snapshot(ppoisweibull(q = 1, shape = 1, scale = 1))
+  expect_snapshot(ppoisweibull(q = 1:10, shape = 1, scale = 1))
   expect_true(is.nan(ppoisweibull(q = NaN, shape = 1, scale = 1)))
   expect_true(is.na(ppoisweibull(q = NA, shape = 1, scale = 1)))
   expect_identical(unname(ppoisweibull(q = "1", shape = 1, scale = 1)), 0)

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -102,6 +102,7 @@ test_that("probability_contain works as when using dots with incorrect name", {
 })
 
 test_that("probability_contain works with <epidist>", {
+  skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -1,90 +1,104 @@
 test_that("probability_contain works as expected for deterministic", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1
-  )
-  expect_equal(prob_contain, 0.76759189)
+  expect_snapshot(probability_contain(R = 1.5, k = 0.5, num_init_infect = 1))
 })
 
 test_that("probability_contain works as expected for stochastic", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, stochastic = TRUE
+  expect_snapshot_value(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, stochastic = TRUE
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  # larger tolerance for stochastic variance
-  expect_equal(prob_contain, 0.76791, tolerance = 1e-2)
 })
 
 test_that("probability_contain works as expected for population control", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1
+  expect_snapshot(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1
+    )
   )
-  expect_equal(prob_contain, 0.821317195)
 })
 
 test_that("probability_contain works as expected for individual control", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1
+  expect_snapshot(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1
+    )
   )
-  expect_equal(prob_contain, 0.839185481)
 })
 
 test_that("probability_contain works as expected for stochastic pop control", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1, stochastic = TRUE
+  expect_snapshot_value(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.1, stochastic = TRUE
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  expect_equal(prob_contain, 0.81881, tolerance = 1e-2)
 })
 
 test_that("probability_contain works as expected for both controls", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1, pop_control = 0.1
+  expect_snapshot(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.1, pop_control = 0.1
+    )
   )
-  expect_equal(prob_contain, 0.891507615)
 })
 
 test_that("probability_contain works as expected for ind control multi init", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 5, ind_control = 0.1
+  expect_snapshot(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 5, ind_control = 0.1
+    )
   )
-  expect_equal(prob_contain, 0.416188242)
 })
 
 test_that("probability_contain works as expected for pop control multi init", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1,
+  expect_snapshot(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 5, pop_control = 0.1,
+    )
   )
-  expect_equal(prob_contain, 0.373727087, tolerance = 1e-2)
 })
 
 test_that("probability_contain works as expected for different threshold", {
-  prob_contain <- probability_contain(
-    R = 1.5,
-    k = 0.5,
-    num_init_infect = 1,
-    stochastic = TRUE,
-    case_threshold = 50
+  expect_snapshot_value(
+    probability_contain(
+      R = 1.5,
+      k = 0.5,
+      num_init_infect = 1,
+      stochastic = TRUE,
+      case_threshold = 50
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  # larger tolerance for stochastic variance
-  expect_equal(prob_contain, 0.76455, tolerance = 1e-2)
 })
 
 test_that("probability_contain works as when using dots", {
-  prob_contain <- probability_contain(
-    R = 1.5,
-    k = 0.5,
-    num_init_infect = 1,
-    n = 1e4,
-    infinite = 50
+  expect_snapshot_value(
+    probability_contain(
+      R = 1.5,
+      k = 0.5,
+      num_init_infect = 1,
+      stochastic = TRUE,
+      n = 1e4,
+      infinite = 50
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  # larger tolerance for stochastic variance
-  expect_equal(prob_contain, 0.76759189, tolerance = 0.1)
 })
 
 test_that("probability_contain works as when using dots with incorrect name", {
-  prob_contain <- probability_contain(
-    R = 1.5, k = 0.5, num_init_infect = 1, random = 100
+  expect_snapshot_value(
+    probability_contain(
+      R = 1.5, k = 0.5, num_init_infect = 1, random = 100
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  # larger tolerance for stochastic variance
-  expect_equal(prob_contain, 0.76759189, tolerance = 1e-2)
 })
 
 test_that("probability_contain works with <epidist>", {
@@ -96,32 +110,29 @@ test_that("probability_contain works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  expect_equal(
+  expect_snapshot(
     probability_contain(
       num_init_infect = 1,
       pop_control = 0.1,
       offspring_dist = edist
-    ),
-    0.903710478
+    )
   )
 
-  expect_equal(
+  expect_snapshot(
     probability_contain(
       num_init_infect = 1,
       ind_control = 0.1,
       offspring_dist = edist
-    ),
-    0.913339427
+    )
   )
 
-  expect_equal(
+  expect_snapshot(
     probability_contain(
       num_init_infect = 5,
       ind_control = 0.1,
       pop_control = 0.1,
       offspring_dist = edist
-    ),
-    0.716891142
+    )
   )
 })
 

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -153,6 +153,6 @@ test_that("probability_contain fails as expected", {
 test_that("probability_contain fails without R and k or <epidist>", {
   expect_error(
     probability_contain(num_init_infect = 1, pop_control = 0.5),
-    regexp = "One of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epidist> must be supplied."
   )
 })

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -95,6 +95,7 @@ test_that("probability_epidemic works for R > 1", {
 })
 
 test_that("probability_epidemic works with <epidist>", {
+  skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -14,17 +14,11 @@ test_that("probability_epidemic works for R < 1", {
 })
 
 test_that("probability_epidemic works for R > 1", {
-  expect_equal(
-    probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1),
-    0.23240811
-  )
+  expect_snapshot(probability_epidemic(R = 1.5, k = 0.5, num_init_infect = 1))
 })
 
 test_that("probability_epidemic works for k == Inf", {
-  expect_equal(
-    probability_epidemic(R = 1.5, k = Inf, num_init_infect = 1),
-    0.58281114
-  )
+  expect_snapshot(probability_epidemic(R = 1.5, k = Inf, num_init_infect = 1))
 })
 
 test_that("probability_epidemic works for different k & num_init_infect", {
@@ -37,33 +31,30 @@ test_that("probability_epidemic works for different k & num_init_infect", {
 })
 
 test_that("probability_epidemic works with individual-level control", {
-  expect_equal(
+  expect_snapshot(
     probability_epidemic(
       R = 1.5, k = 0.5, num_init_infect = 1, ind_control = 0.2
-    ),
-    0.0907059844
+    )
   )
 })
 
 test_that("probability_epidemic works with population-level control", {
-  expect_equal(
+  expect_snapshot(
     probability_epidemic(
       R = 1.5, k = 0.5, num_init_infect = 1, pop_control = 0.2
-    ),
-    0.11338249
+    )
   )
 })
 
 test_that("probability_epidemic works with both control measures", {
-  expect_equal(
+  expect_snapshot(
     probability_epidemic(
       R = 1.5,
       k = 0.5,
       num_init_infect = 1,
       ind_control = 0.1,
       pop_control = 0.1
-    ),
-    0.108492385
+    )
   )
 })
 
@@ -98,9 +89,8 @@ test_that("probability_extinct works for R < 1", {
 })
 
 test_that("probability_epidemic works for R > 1", {
-  expect_equal(
-    probability_extinct(R = 1.5, k = 0.5, num_init_infect = 1),
-    0.76759189
+  expect_snapshot(
+    probability_extinct(R = 1.5, k = 0.5, num_init_infect = 1)
   )
 })
 
@@ -113,9 +103,8 @@ test_that("probability_epidemic works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  expect_equal(
-    probability_epidemic(num_init_infect = 1, offspring_dist = edist),
-    0.119870497
+  expect_snapshot(
+    probability_epidemic(num_init_infect = 1, offspring_dist = edist)
   )
 })
 
@@ -127,7 +116,7 @@ test_that("probability_epidemic fails without R and k or <epidist>", {
 })
 
 test_that("probability_epidemic works with grid", {
-  expect_equal(
+  expect_snapshot(
     probability_epidemic(
       R = 1.5,
       k = 1,
@@ -135,13 +124,12 @@ test_that("probability_epidemic works with grid", {
       ind_control = 0.1,
       pop_control = 0.1,
       fit_method = "grid"
-    ),
-    0.579292767
+    )
   )
 })
 
 test_that("probability_epidemic works with spliced list", {
-  expect_equal(
+  expect_snapshot(
     probability_epidemic(
       R = 1.5,
       k = 1,
@@ -149,7 +137,6 @@ test_that("probability_epidemic works with spliced list", {
       ind_control = 0.1,
       pop_control = 0.1,
       !!!list(fit_method = "grid")
-    ),
-    0.579292767
+    )
   )
 })

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -111,7 +111,7 @@ test_that("probability_epidemic works with <epidist>", {
 test_that("probability_epidemic fails without R and k or <epidist>", {
   expect_error(
     probability_epidemic(num_init_infect = 1),
-    regexp = "One of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epidist> must be supplied."
   )
 })
 

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -55,18 +55,15 @@ test_that("proportion_cluster_size works as expected for multiple R & k & cs", {
 })
 
 test_that("proportion_cluster_size works as expected for format_prop = FALSE", {
-  res <- proportion_cluster_size(
-    R = c(1, 2, 3),
-    k = c(0.1, 0.2, 0.3),
-    cluster_size = c(5, 10, 25),
-    format_prop = FALSE
-  )
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(9L, 5L))
-  expect_identical(
-    unname(vapply(res, class, FUN.VALUE = character(1))),
-    rep("numeric", 5)
+  expect_snapshot_value(
+    proportion_cluster_size(
+      R = c(1, 2, 3),
+      k = c(0.1, 0.2, 0.3),
+      cluster_size = c(5, 10, 25),
+      format_prop = FALSE
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
 })
 

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -106,6 +106,6 @@ test_that("proportion_cluster_size works with <epidist>", {
 test_that("proportion_cluster_size fails without R and k or <epidist>", {
   expect_error(
     proportion_cluster_size(cluster_size = 10),
-    regexp = "One of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epidist> must be supplied."
   )
 })

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -63,7 +63,7 @@ test_that("proportion_cluster_size works as expected for format_prop = FALSE", {
       format_prop = FALSE
     ),
     style = "json2",
-    tolerance = 0.01
+    tolerance = 0.1
   )
 })
 

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -85,6 +85,7 @@ test_that("proportion_cluster_size fails as expected", {
 })
 
 test_that("proportion_cluster_size works with <epidist>", {
+  skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -1,11 +1,6 @@
 test_that("proportion_transmission works as expected for single R and k", {
-  res <- proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.8)
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(1L, 3L))
-  expect_identical(
-    unname(vapply(res, class, character(1))),
-    c("numeric", "numeric", "character")
+  expect_snapshot(
+    proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.8)
   )
 
   res <- proportion_transmission(
@@ -24,17 +19,12 @@ test_that("proportion_transmission works as expected for single R and k", {
 })
 
 test_that("proportion_transmission works as expected for multiple R", {
-  res <- proportion_transmission(
-    R = c(1, 2, 3),
-    k = 0.5,
-    percent_transmission = 0.8
-  )
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(3L, 3L))
-  expect_identical(
-    unname(vapply(res, class, character(1))),
-    c("numeric", "numeric", "character")
+  expect_snapshot(
+    proportion_transmission(
+      R = c(1, 2, 3),
+      k = 0.5,
+      percent_transmission = 0.8
+    )
   )
 
   res <- proportion_transmission(
@@ -53,17 +43,12 @@ test_that("proportion_transmission works as expected for multiple R", {
 })
 
 test_that("proportion_transmission works as expected for multiple R & k", {
-  res <- proportion_transmission(
-    R = c(1, 2, 3),
-    k = c(0.1, 0.2, 0.3),
-    percent_transmission = 0.8
-  )
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(9L, 3L))
-  expect_identical(
-    unname(vapply(res, class, character(1))),
-    c("numeric", "numeric", "character")
+  expect_snapshot(
+    proportion_transmission(
+      R = c(1, 2, 3),
+      k = c(0.1, 0.2, 0.3),
+      percent_transmission = 0.8
+    )
   )
 
   res <- proportion_transmission(
@@ -82,18 +67,13 @@ test_that("proportion_transmission works as expected for multiple R & k", {
 })
 
 test_that("proportion_transmission works as expected for format_prop = FALSE", {
-  res <- proportion_transmission(
-    R = c(1, 2, 3),
-    k = c(0.1, 0.2, 0.3),
-    percent_transmission = 0.8,
-    format_prop = FALSE
-  )
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(9L, 3L))
-  expect_identical(
-    unname(vapply(res, class, character(1))),
-    rep("numeric", 3)
+  expect_snapshot(
+    proportion_transmission(
+      R = c(1, 2, 3),
+      k = c(0.1, 0.2, 0.3),
+      percent_transmission = 0.8,
+      format_prop = FALSE
+    )
   )
 })
 
@@ -125,23 +105,25 @@ test_that("proportion_transmission fails as expected", {
 })
 
 test_that(".prop_transmission_numerical works as expected", {
-  res <- .prop_transmission_numerical(
-    R = 2,
-    k = 0.5,
-    percent_transmission = 0.8
+  expect_snapshot_value(
+    .prop_transmission_numerical(
+      R = 2,
+      k = 0.5,
+      percent_transmission = 0.8
+    ),
+    style = "json2",
+    tolerance = 0.01
   )
-  expect_type(res, "double")
-  expect_length(res, 1)
 })
 
 test_that(".prop_transmission_analytical works as expected", {
-  res <- .prop_transmission_analytical(
-    R = 2,
-    k = 0.5,
-    percent_transmission = 0.8
+  expect_snapshot(
+    .prop_transmission_analytical(
+      R = 2,
+      k = 0.5,
+      percent_transmission = 0.8
+    )
   )
-  expect_type(res, "double")
-  expect_length(res, 1)
 })
 
 test_that("proportion_transmission works with <epidist>", {
@@ -153,16 +135,11 @@ test_that("proportion_transmission works with <epidist>", {
       single_epidist = TRUE
     )
   )
-  res <- proportion_transmission(
-    percent_transmission = 0.8,
-    offspring_dist = edist
-  )
-
-  expect_s3_class(res, "data.frame")
-  expect_identical(dim(res), c(1L, 3L))
-  expect_identical(
-    unname(vapply(res, class, character(1))),
-    c("numeric", "numeric", "character")
+  expect_snapshot(
+    proportion_transmission(
+      percent_transmission = 0.8,
+      offspring_dist = edist
+    )
   )
 })
 

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -146,6 +146,6 @@ test_that("proportion_transmission works with <epidist>", {
 test_that("proportion_transmission fails without R and k or <epidist>", {
   expect_error(
     proportion_transmission(percent_transmission = 0.8),
-    regexp = "One of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epidist> must be supplied."
   )
 })

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -127,6 +127,7 @@ test_that(".prop_transmission_analytical works as expected", {
 })
 
 test_that("proportion_transmission works with <epidist>", {
+  skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -27,7 +27,7 @@ test_that("get_param fails as expected", {
 test_that("get_param fails as expected with incorrect parameters", {
   skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
-    epidist_db(
+    epiparameter::epidist_db(
       disease = "COVID-19",
       epi_dist = "incubation period",
       author = "Linton",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,19 +1,22 @@
-library(epiparameter)
-edist <- suppressMessages(
-  epidist_db(
-    disease = "SARS",
-    epi_dist = "offspring distribution",
-    author = "Lloyd-Smith",
-    single_epidist = TRUE
+if (requireNamespace("epiparameterr", quietly = TRUE)) {
+  edist <- suppressMessages(
+    epiparameter::epidist_db(
+      disease = "SARS",
+      epi_dist = "offspring distribution",
+      author = "Lloyd-Smith",
+      single_epidist = TRUE
+    )
   )
-)
+}
 
 test_that("get_param works as expected", {
+  skip_if_not_installed(pkg = "epiparameter")
   expect_type(get_epidist_param(epidist = edist, parameter = "R"), "double")
   expect_type(get_epidist_param(epidist = edist, parameter = "k"), "double")
 })
 
 test_that("get_param fails as expected", {
+  skip_if_not_installed(pkg = "epiparameter")
   expect_error(
     get_epidist_param(epidist = edist, parameter = "random"),
     regexp = "(arg)*(should be one of)*(R)*(k)"
@@ -22,6 +25,7 @@ test_that("get_param fails as expected", {
 })
 
 test_that("get_param fails as expected with incorrect parameters", {
+  skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
     epidist_db(
       disease = "COVID-19",
@@ -37,6 +41,7 @@ test_that("get_param fails as expected with incorrect parameters", {
 })
 
 test_that("ic_tbl works as expected", {
+  skip_if_not_installed(pkg = "fitdistrplus")
   set.seed(1)
   cases <- rnbinom(n = 100, mu = 5, size = 0.7)
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
@@ -46,6 +51,7 @@ test_that("ic_tbl works as expected", {
 })
 
 test_that("ic_tbl works as expected with sort_by = BIC", {
+  skip_if_not_installed(pkg = "fitdistrplus")
   set.seed(1)
   cases <- rnbinom(n = 100, mu = 5, size = 0.7)
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
@@ -55,6 +61,7 @@ test_that("ic_tbl works as expected with sort_by = BIC", {
 })
 
 test_that("ic_tbl works as expected with sort_by = none", {
+  skip_if_not_installed(pkg = "fitdistrplus")
   set.seed(1)
   cases <- rnbinom(n = 100, mu = 5, size = 0.7)
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
@@ -64,6 +71,7 @@ test_that("ic_tbl works as expected with sort_by = none", {
 })
 
 test_that("ic_tbl fails as expected", {
+  skip_if_not_installed(pkg = "fitdistrplus")
   cases <- rnbinom(n = 100, mu = 5, size = 0.7)
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
   geom_fit <- fitdistrplus::fitdist(data = cases, distr = "geom")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,4 +1,4 @@
-if (requireNamespace("epiparameterr", quietly = TRUE)) {
+if (requireNamespace("epiparameter", quietly = TRUE)) {
   edist <- suppressMessages(
     epiparameter::epidist_db(
       disease = "SARS",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -42,10 +42,7 @@ test_that("ic_tbl works as expected", {
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
   geom_fit <- fitdistrplus::fitdist(data = cases, distr = "geom")
   nbinom_fit <- fitdistrplus::fitdist(data = cases, distr = "nbinom")
-  tbl <- ic_tbl(pois_fit, geom_fit, nbinom_fit)
-  expect_s3_class(tbl, class = "data.frame")
-  expect_identical(dim(tbl), c(3L, 7L))
-  expect_identical(tbl$distribution, c("nbinom", "geom", "pois"))
+  expect_snapshot(ic_tbl(pois_fit, geom_fit, nbinom_fit))
 })
 
 test_that("ic_tbl works as expected with sort_by = BIC", {
@@ -54,10 +51,7 @@ test_that("ic_tbl works as expected with sort_by = BIC", {
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
   geom_fit <- fitdistrplus::fitdist(data = cases, distr = "geom")
   nbinom_fit <- fitdistrplus::fitdist(data = cases, distr = "nbinom")
-  tbl <- ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "BIC")
-  expect_s3_class(tbl, class = "data.frame")
-  expect_identical(dim(tbl), c(3L, 7L))
-  expect_identical(tbl$distribution, c("nbinom", "geom", "pois"))
+  expect_snapshot(ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "BIC"))
 })
 
 test_that("ic_tbl works as expected with sort_by = none", {
@@ -66,10 +60,7 @@ test_that("ic_tbl works as expected with sort_by = none", {
   pois_fit <- fitdistrplus::fitdist(data = cases, distr = "pois")
   geom_fit <- fitdistrplus::fitdist(data = cases, distr = "geom")
   nbinom_fit <- fitdistrplus::fitdist(data = cases, distr = "nbinom")
-  tbl <- ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "none")
-  expect_s3_class(tbl, class = "data.frame")
-  expect_identical(dim(tbl), c(3L, 7L))
-  expect_identical(tbl$distribution, c("pois", "geom", "nbinom"))
+  expect_snapshot(ic_tbl(pois_fit, geom_fit, nbinom_fit, sort_by = "none"))
 })
 
 test_that("ic_tbl fails as expected", {


### PR DESCRIPTION
This PR updates the testing following suggestions from the package review (#77). The error message when `R` and `k` or `<epidist>` are incorrectly supplied is clarified, snapshot testing is used for regression unit tests, and tests are guarded with `skip_if_not_installed()` and `requireNamespace()` when using packages that are suggested dependencies (CRAN policy). 