### PR TITLE
Use dynamic dots in `probability_contain()`

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -60,6 +60,7 @@ num
 ORCID
 Oumar
 Ousmane
+parameterised
 params
 pkgdown
 pointrange

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -37,7 +37,8 @@ control measures. Between \code{0} (default) and \code{1} (maximum).}
 analytical probability of extinction. Default (\code{FALSE}) is to use the
 analytical calculation.}
 
-\item{...}{arguments to be passed to \code{\link[bpmodels:chain_sim]{bpmodels::chain_sim()}}.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Named elements to replace
+default arguments in \code{\link[bpmodels:chain_sim]{bpmodels::chain_sim()}}. See details.}
 
 \item{case_threshold}{A number for the threshold of the number of cases below
 which the epidemic is considered contained.}
@@ -51,6 +52,12 @@ A \code{number} for the probability of containment.
 \description{
 Containment is defined as the size of the transmission chain
 not reaching the \code{case_threshold} (default = 100).
+}
+\details{
+When using \code{stochastic = TRUE}, the default arguments to simulate the
+transmission chains with \code{\link[bpmodels:chain_sim]{bpmodels::chain_sim()}} are \code{1e5} replicates,
+a negative binomial (\code{nbinom}) offspring distribution, parameterised with
+\code{R} (and \code{pop_control} if > 0) and \code{k}.
 }
 \examples{
 # population-level control measures

--- a/tests/testthat/_snaps/probability_contain.md
+++ b/tests/testthat/_snaps/probability_contain.md
@@ -73,13 +73,6 @@
       "value": [0.7636]
     }
 
-# probability_contain works as when using dots with incorrect name
-
-    Code
-      probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, random = 100)
-    Output
-      [1] 0.7675919
-
 # probability_contain works with <epidist>
 
     Code

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -91,12 +91,6 @@ test_that("probability_contain works as when using dots", {
   )
 })
 
-test_that("probability_contain works as when using dots with incorrect name", {
-  expect_snapshot(
-    probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, random = 100)
-  )
-})
-
 test_that("probability_contain works with <epidist>", {
   skip_if_not_installed(pkg = "epiparameter")
   edist <- suppressMessages(
@@ -144,6 +138,13 @@ test_that("probability_contain fails as expected", {
     ),
     regexp =
       "individual-level control not yet implemented for stochastic calculation"
+  )
+})
+
+test_that("probability_contain fails using dots with incorrect name", {
+  expect_error(
+    probability_contain(R = 1.5, k = 0.5, num_init_infect = 1, random = 100),
+    regexp = "Arguments supplied in `...` not valid"
   )
 })
 


### PR DESCRIPTION
This PR adds the use of [dynamic dots](https://rlang.r-lib.org/reference/dyn-dots.html) to `probability_contain()`. The function now errors when an argument is passed through `...` but does not match arguments in `bpmodels::chain_sim()`, instead of silently ignoring the incorrect argument. This is to match the behaviour of other Epiverse-TRACE functions. The documentation and a test of `probability_contain()` have been updated to explain and test the new features/behaviour.