### PR TITLE
Fix ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,14 +8,14 @@ Authors@R:
             family = "Lambert",
             role = c("aut", "cre", "cph"),
             email = "joshua.lambert@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5218-3046")
+            comment = c(ORCID = "0000-0001-5218-3046")
         ),
         person(
             given = "Adam", 
             family = "Kucharski",
             role = c("aut", "cph"),
             email = "adam.kucharski@lshtm.ac.uk", 
-            comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421")
+            comment = c(ORCID = "0000-0001-8814-9421")
         ),
         person(
             given = "Sebastian",
@@ -29,21 +29,21 @@ Authors@R:
             family = "Gupte",
             role = c("rev"),
             email = "pratik.gupte@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")
+            comment = c(ORCID = "0000-0001-5294-7819")
         ),
         person(
             given = "Hugo",
             family = "Gruson",
             role = c("rev"),
             email = "hugo@data.org",
-            comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")
+            comment = c(ORCID = "0000-0002-4094-1476")
         ),
         person(
             given = "James M.",
             family = "Azam", 
             role = c("rev"),
             email = "james.azam@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5782-7330")
+            comment = c(ORCID = "0000-0001-5782-7330")
         )
     )
 Description: Implements functions to estimate individual-level variation in 


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126