### PR TITLE
Add lintr GHA workflow

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '**.R'
+      - '**.Rmd'
+      - '**/.lintr'
+      - '**/.lintr.R'
+
+name: lint-changed-files
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::gh
+            any::lintr
+            any::purrr
+            epiverse-trace/etdev
+          needs: check
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -4,6 +4,7 @@ linters: all_linters(
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    library_call_linter = NULL,
     undesirable_function_linter(
       modify_defaults(
         default_undesirable_functions,


### PR DESCRIPTION
This PR reintroduces the `lint-changed-files.yaml` GitHub action workflow as it is no longer being trigger from the `epiverse-trace/.github` organisation repository. The workflow was previously in the package, but has been removed since #7.

The `library_call_linter` is also set to `NULL` in the `.lintr` file.