### PR TITLE
Improve `proportion_transmission()` argument documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
-# -----------------------------------------------------------
-# CITATION file created with {cffr} R package, v0.5.0
+# --------------------------------------------
+# CITATION file created with {cffr} R package
 # See also: https://docs.ropensci.org/cffr/
-# -----------------------------------------------------------
+# --------------------------------------------
  
 cff-version: 1.2.0
 message: 'To cite package "superspreading" in publications use:'
@@ -51,11 +51,10 @@ references:
   notes: Imports
   authors:
   - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2024'
 - type: software
   title: bpmodels
   abstract: 'bpmodels: Simulating and Analysing Transmission Chain Statistics using
@@ -227,12 +226,16 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
+  - family-names: Brand
+    given-names: Teun
+    name-particle: van den
+    orcid: https://orcid.org/0000-0002-9335-7468
   year: '2024'
 - type: software
   title: spelling
   abstract: 'spelling: Tools for Spell Checking in R'
   notes: Suggests
-  url: https://docs.ropensci.org/spelling/
+  url: https://ropensci.r-universe.dev/spelling
   repository: https://CRAN.R-project.org/package=spelling
   authors:
   - family-names: Ooms
@@ -288,3 +291,4 @@ references:
     email: hadley@posit.co
   year: '2024'
   version: '>= 3.0.0'
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ URL: https://github.com/epiverse-trace/superspreading, https://epiverse-trace.gi
 BugReports: https://github.com/epiverse-trace/superspreading/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Imports:
     checkmate,
     stats,

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -21,7 +21,8 @@
 #' @param percent_transmission A `number` of the percentage transmission
 #' for which a proportion of cases has produced.
 #' @param simulate A `logical` whether the calculation should be done
-#' numerically (i.e. simulate secondary contacts) or analytically.
+#' numerically (i.e. simulate secondary contacts) or analytically. Default is
+#' `FALSE` which uses the analytical calculation.
 #'
 #' @return A `<data.frame>` with the value for the proportion of cases for a
 #' given value of R and k.

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -26,7 +26,8 @@ offspring distribution from fitted negative binomial).}
 for which a proportion of cases has produced.}
 
 \item{simulate}{A \code{logical} whether the calculation should be done
-numerically (i.e. simulate secondary contacts) or analytically.}
+numerically (i.e. simulate secondary contacts) or analytically. Default is
+\code{FALSE} which uses the analytical calculation.}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 


### PR DESCRIPTION
This PR addresses #94 by clarifying the default behaviour of `proportion_transmission()` from the `simulate` argument.