### PR TITLE
Update {epiparameter} usage

### DIFF
--- a/R/probability_contain.R
+++ b/R/probability_contain.R
@@ -70,13 +70,16 @@ probability_contain <- function(R,
 
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop(
+      "Only one of R and k or <epiparameter> must be supplied.",
+      call. = FALSE
+    )
   }
   # check inputs
   if (input_params) {
-    checkmate::assert_class(offspring_dist, classes = "epidist")
-    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
-    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
+    checkmate::assert_class(offspring_dist, classes = "epiparameter")
+    R <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "R")
+    k <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "k")
   }
   checkmate::assert_number(R, lower = 0, finite = TRUE)
   checkmate::assert_number(k, lower = 0)

--- a/R/probability_epidemic.R
+++ b/R/probability_epidemic.R
@@ -20,8 +20,9 @@
 #' default optimisation settings. Currently only `"fit_method"` is accepted
 #' and can be either `"optim"` (default) or `"grid"` for numerical
 #' optimisation routine or grid search, respectively.
-#' @param offspring_dist An `<epidist>` object. An S3 class for working with
-#' epidemiological parameters/distributions, see [epiparameter::epidist()].
+#' @param offspring_dist An `<epiparameter>` object. An S3 class for working
+#' with epidemiological parameters/distributions, see
+#' [epiparameter::epiparameter()].
 #'
 #' @return A value with the probability of a large epidemic.
 #' @export
@@ -89,14 +90,17 @@ probability_extinct <- function(R,
                                 offspring_dist) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop(
+      "Only one of R and k or <epiparameter> must be supplied.",
+      call. = FALSE
+    )
   }
 
   # check inputs
   if (input_params) {
-    checkmate::assert_class(offspring_dist, classes = "epidist")
-    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
-    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
+    checkmate::assert_class(offspring_dist, classes = "epiparameter")
+    R <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "R")
+    k <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "k")
   }
 
   checkmate::assert_number(R, lower = 0, finite = TRUE)

--- a/R/proportion_cluster_size.R
+++ b/R/proportion_cluster_size.R
@@ -44,15 +44,18 @@ proportion_cluster_size <- function(R, k, cluster_size, ..., offspring_dist,
                                     format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop(
+      "Only one of R and k or <epiparameter> must be supplied.",
+      call. = FALSE
+    )
   }
 
   # check inputs
   chkDots(...)
   if (input_params) {
-    checkmate::assert_class(offspring_dist, classes = "epidist")
-    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
-    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
+    checkmate::assert_class(offspring_dist, classes = "epiparameter")
+    R <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "R")
+    k <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "k")
   }
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)

--- a/R/proportion_transmission.R
+++ b/R/proportion_transmission.R
@@ -71,15 +71,18 @@ proportion_transmission <- function(R, k,
                                     format_prop = TRUE) {
   input_params <- missing(R) && missing(k)
   if (!xor(input_params, missing(offspring_dist))) {
-    stop("Only one of R and k or <epidist> must be supplied.", call. = FALSE)
+    stop(
+      "Only one of R and k or <epiparameter> must be supplied.",
+      call. = FALSE
+    )
   }
 
   # check inputs
   chkDots(...)
   if (input_params) {
-    checkmate::assert_class(offspring_dist, classes = "epidist")
-    R <- get_epidist_param(epidist = offspring_dist, parameter = "R")
-    k <- get_epidist_param(epidist = offspring_dist, parameter = "k")
+    checkmate::assert_class(offspring_dist, classes = "epiparameter")
+    R <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "R")
+    k <- get_epiparameter_param(epiparameter = offspring_dist, parameter = "k")
   }
   checkmate::assert_numeric(R, lower = 0, finite = TRUE)
   checkmate::assert_numeric(k, lower = 0)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-#' Get a parameter out of <epidist>
+#' Get a parameter out of <epiparameter>
 #'
 #' @inheritParams probability_epidemic
 #' @param parameter A character string, either `"R"` or `"k"`.
@@ -6,13 +6,13 @@
 #' @return An unnamed numeric.
 #' @keywords internal
 #' @noRd
-get_epidist_param <- function(epidist,
-                              parameter = c("R", "k")) {
-  # check inputs (<epidist> already checked)
+get_epiparameter_param <- function(epiparameter,
+                                   parameter = c("R", "k")) {
+  # check inputs (<epiparameter> already checked)
   parameter <- match.arg(parameter)
 
-  # extract parameters from <epidist>
-  params <- epiparameter::get_parameters(epidist)
+  # extract parameters from <epiparameter>
+  params <- epiparameter::get_parameters(epiparameter)
 
   regexpr_pattern <- switch(parameter,
     R = "^r$|^r0$|^mean$",
@@ -28,7 +28,10 @@ get_epidist_param <- function(epidist,
   if (length(idx) == 0) {
     stop(
       sprintf(
-        "Cannot find %s in <epidist>, check if parameters have correct names.",
+        paste(
+          "Cannot find %s in <epiparameter>,",
+          "check if parameters have correct names."
+        ),
         parameter
       ),
       call. = FALSE

--- a/man/probability_contain.Rd
+++ b/man/probability_contain.Rd
@@ -43,8 +43,9 @@ default arguments in \code{\link[bpmodels:chain_sim]{bpmodels::chain_sim()}}. Se
 \item{case_threshold}{A number for the threshold of the number of cases below
 which the epidemic is considered contained.}
 
-\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+\item{offspring_dist}{An \verb{<epiparameter>} object. An S3 class for working
+with epidemiological parameters/distributions, see
+\code{\link[epiparameter:epiparameter]{epiparameter::epiparameter()}}.}
 }
 \value{
 A \code{number} for the probability of containment.

--- a/man/probability_epidemic.Rd
+++ b/man/probability_epidemic.Rd
@@ -37,8 +37,9 @@ default optimisation settings. Currently only \code{"fit_method"} is accepted
 and can be either \code{"optim"} (default) or \code{"grid"} for numerical
 optimisation routine or grid search, respectively.}
 
-\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+\item{offspring_dist}{An \verb{<epiparameter>} object. An S3 class for working
+with epidemiological parameters/distributions, see
+\code{\link[epiparameter:epiparameter]{epiparameter::epiparameter()}}.}
 }
 \value{
 A value with the probability of a large epidemic.

--- a/man/probability_extinct.Rd
+++ b/man/probability_extinct.Rd
@@ -37,8 +37,9 @@ default optimisation settings. Currently only \code{"fit_method"} is accepted
 and can be either \code{"optim"} (default) or \code{"grid"} for numerical
 optimisation routine or grid search, respectively.}
 
-\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+\item{offspring_dist}{An \verb{<epiparameter>} object. An S3 class for working
+with epidemiological parameters/distributions, see
+\code{\link[epiparameter:epiparameter]{epiparameter::epiparameter()}}.}
 }
 \value{
 A value with the probability of going extinct.

--- a/man/proportion_cluster_size.Rd
+++ b/man/proportion_cluster_size.Rd
@@ -25,8 +25,9 @@ offspring distribution from fitted negative binomial).}
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+\item{offspring_dist}{An \verb{<epiparameter>} object. An S3 class for working
+with epidemiological parameters/distributions, see
+\code{\link[epiparameter:epiparameter]{epiparameter::epiparameter()}}.}
 
 \item{format_prop}{A \code{logical} determining whether the proportion column
 of the \verb{<data.frame>} returned by the function is formatted as a string with

--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -31,8 +31,9 @@ numerically (i.e. simulate secondary contacts) or analytically. Default is
 
 \item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 
-\item{offspring_dist}{An \verb{<epidist>} object. An S3 class for working with
-epidemiological parameters/distributions, see \code{\link[epiparameter:epidist]{epiparameter::epidist()}}.}
+\item{offspring_dist}{An \verb{<epiparameter>} object. An S3 class for working
+with epidemiological parameters/distributions, see
+\code{\link[epiparameter:epiparameter]{epiparameter::epiparameter()}}.}
 
 \item{format_prop}{A \code{logical} determining whether the proportion column
 of the \verb{<data.frame>} returned by the function is formatted as a string with

--- a/tests/testthat/_snaps/probability_contain.md
+++ b/tests/testthat/_snaps/probability_contain.md
@@ -73,17 +73,17 @@
       "value": [0.7636]
     }
 
-# probability_contain works with <epidist>
+# probability_contain works with <epiparameter>
 
     Code
-      probability_contain(num_init_infect = 1, pop_control = 0.1, offspring_dist = edist)
+      probability_contain(num_init_infect = 1, pop_control = 0.1, offspring_dist = od)
     Output
       [1] 0.9037105
 
 ---
 
     Code
-      probability_contain(num_init_infect = 1, ind_control = 0.1, offspring_dist = edist)
+      probability_contain(num_init_infect = 1, ind_control = 0.1, offspring_dist = od)
     Output
       [1] 0.9133394
 
@@ -91,7 +91,7 @@
 
     Code
       probability_contain(num_init_infect = 5, ind_control = 0.1, pop_control = 0.1,
-        offspring_dist = edist)
+        offspring_dist = od)
     Output
       [1] 0.7168911
 

--- a/tests/testthat/_snaps/probability_epidemic.md
+++ b/tests/testthat/_snaps/probability_epidemic.md
@@ -41,10 +41,10 @@
     Output
       [1] 0.1084924
 
-# probability_epidemic works with <epidist>
+# probability_epidemic works with <epiparameter>
 
     Code
-      probability_epidemic(num_init_infect = 1, offspring_dist = edist)
+      probability_epidemic(num_init_infect = 1, offspring_dist = od)
     Output
       [1] 0.1198705
 

--- a/tests/testthat/_snaps/proportion_transmission.md
+++ b/tests/testthat/_snaps/proportion_transmission.md
@@ -65,10 +65,10 @@
     Output
       [1] 0.264419
 
-# proportion_transmission works with <epidist>
+# proportion_transmission works with <epiparameter>
 
     Code
-      proportion_transmission(percent_transmission = 0.8, offspring_dist = edist)
+      proportion_transmission(percent_transmission = 0.8, offspring_dist = od)
     Output
            R    k prop_80
       1 1.63 0.16     13%

--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -91,21 +91,21 @@ test_that("probability_contain works as when using dots", {
   )
 })
 
-test_that("probability_contain works with <epidist>", {
+test_that("probability_contain works with <epiparameter>", {
   skip_if_not_installed(pkg = "epiparameter")
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "SARS",
       epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
   expect_snapshot(
     probability_contain(
       num_init_infect = 1,
       pop_control = 0.1,
-      offspring_dist = edist
+      offspring_dist = od
     )
   )
 
@@ -113,7 +113,7 @@ test_that("probability_contain works with <epidist>", {
     probability_contain(
       num_init_infect = 1,
       ind_control = 0.1,
-      offspring_dist = edist
+      offspring_dist = od
     )
   )
 
@@ -122,7 +122,7 @@ test_that("probability_contain works with <epidist>", {
       num_init_infect = 5,
       ind_control = 0.1,
       pop_control = 0.1,
-      offspring_dist = edist
+      offspring_dist = od
     )
   )
 })
@@ -148,9 +148,9 @@ test_that("probability_contain fails using dots with incorrect name", {
   )
 })
 
-test_that("probability_contain fails without R and k or <epidist>", {
+test_that("probability_contain fails without R and k or <epiparameter>", {
   expect_error(
     probability_contain(num_init_infect = 1, pop_control = 0.5),
-    regexp = "Only one of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epiparameter> must be supplied."
   )
 })

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -94,25 +94,25 @@ test_that("probability_epidemic works for R > 1", {
   )
 })
 
-test_that("probability_epidemic works with <epidist>", {
+test_that("probability_epidemic works with <epiparameter>", {
   skip_if_not_installed(pkg = "epiparameter")
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "SARS",
       epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
   expect_snapshot(
-    probability_epidemic(num_init_infect = 1, offspring_dist = edist)
+    probability_epidemic(num_init_infect = 1, offspring_dist = od)
   )
 })
 
-test_that("probability_epidemic fails without R and k or <epidist>", {
+test_that("probability_epidemic fails without R and k or <epiparameter>", {
   expect_error(
     probability_epidemic(num_init_infect = 1),
-    regexp = "Only one of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epiparameter> must be supplied."
   )
 })
 

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -84,17 +84,17 @@ test_that("proportion_cluster_size fails as expected", {
   )
 })
 
-test_that("proportion_cluster_size works with <epidist>", {
+test_that("proportion_cluster_size works with <epiparameter>", {
   skip_if_not_installed(pkg = "epiparameter")
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "SARS",
       epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
-  res <- proportion_cluster_size(cluster_size = 20, offspring_dist = edist)
+  res <- proportion_cluster_size(cluster_size = 20, offspring_dist = od)
 
   expect_s3_class(res, "data.frame")
   expect_identical(dim(res), c(1L, 3L))
@@ -104,9 +104,9 @@ test_that("proportion_cluster_size works with <epidist>", {
   )
 })
 
-test_that("proportion_cluster_size fails without R and k or <epidist>", {
+test_that("proportion_cluster_size fails without R and k or <epiparameter>", {
   expect_error(
     proportion_cluster_size(cluster_size = 10),
-    regexp = "Only one of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epiparameter> must be supplied."
   )
 })

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -126,27 +126,27 @@ test_that(".prop_transmission_analytical works as expected", {
   )
 })
 
-test_that("proportion_transmission works with <epidist>", {
+test_that("proportion_transmission works with <epiparameter>", {
   skip_if_not_installed(pkg = "epiparameter")
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "SARS",
       epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
   expect_snapshot(
     proportion_transmission(
       percent_transmission = 0.8,
-      offspring_dist = edist
+      offspring_dist = od
     )
   )
 })
 
-test_that("proportion_transmission fails without R and k or <epidist>", {
+test_that("proportion_transmission fails without R and k or <epiparameter>", {
   expect_error(
     proportion_transmission(percent_transmission = 0.8),
-    regexp = "Only one of R and k or <epidist> must be supplied."
+    regexp = "Only one of R and k or <epiparameter> must be supplied."
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,41 +1,41 @@
 if (requireNamespace("epiparameter", quietly = TRUE)) {
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "SARS",
       epi_dist = "offspring distribution",
       author = "Lloyd-Smith",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
 }
 
 test_that("get_param works as expected", {
   skip_if_not_installed(pkg = "epiparameter")
-  expect_type(get_epidist_param(epidist = edist, parameter = "R"), "double")
-  expect_type(get_epidist_param(epidist = edist, parameter = "k"), "double")
+  expect_type(get_epiparameter_param(epiparameter = od, parameter = "R"), "double")
+  expect_type(get_epiparameter_param(epiparameter = od, parameter = "k"), "double")
 })
 
 test_that("get_param fails as expected", {
   skip_if_not_installed(pkg = "epiparameter")
   expect_error(
-    get_epidist_param(epidist = edist, parameter = "random"),
+    get_epiparameter_param(epiparameter = od, parameter = "random"),
     regexp = "(arg)*(should be one of)*(R)*(k)"
   )
-  expect_error(get_epidist_param(epidist = list(), parameter = "R"))
+  expect_error(get_epiparameter_param(epiparameter = list(), parameter = "R"))
 })
 
 test_that("get_param fails as expected with incorrect parameters", {
   skip_if_not_installed(pkg = "epiparameter")
-  edist <- suppressMessages(
-    epiparameter::epidist_db(
+  od <- suppressMessages(
+    epiparameter::epiparameter_db(
       disease = "COVID-19",
       epi_dist = "incubation period",
       author = "Linton",
-      single_epidist = TRUE
+      single_epiparameter = TRUE
     )
   )
   expect_error(
-    get_epidist_param(epidist = edist, parameter = "R"),
+    get_epiparameter_param(epiparameter = od, parameter = "R"),
     regexp = "(arg)*(should be one of)*(R)*(k)"
   )
 })

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -38,7 +38,7 @@ The distribution functions return a vector of `numeric`s of equal length to the 
 
 - The distribution functions are vectorised (i.e. wrapped in `Vectorize()`). This enables them to be used identically to base R distribution functions.
 
-- Native interoperability with `<epidist>` objects, from the {epiparameter} package is enabled for `probability_*()` and `proportion_*()` via the `offspring_dist` argument. This allows user to pass in a single object and the parameters required by the {superspreading} function will be extracted, if these are not available within the `<epidist>` object the function returns an informative error. The `offspring_dist` argument is after `...` to ensure users specify the argument in full and not accidentally provide data to this argument.
+- Native interoperability with `<epiparameter>` objects, from the {epiparameter} package is enabled for `probability_*()` and `proportion_*()` via the `offspring_dist` argument. This allows user to pass in a single object and the parameters required by the {superspreading} function will be extracted, if these are not available within the `<epiparameter>` object the function returns an informative error. The `offspring_dist` argument is after `...` to ensure users specify the argument in full and not accidentally provide data to this argument.
 
 - Internal functions have a dot (`.`) prefix, exported functions do not.
 

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -121,15 +121,15 @@ Here we can use [{epiparameter}](https://github.com/epiverse-trace/epiparameter)
 diseases and evaluate how likely they are to cause epidemics.
 
 ```{r, epiparam}
-sars <- epidist_db(
+sars <- epiparameter_db(
   disease = "SARS",
   epi_dist = "offspring distribution",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
-evd <- epidist_db(
+evd <- epiparameter_db(
   disease = "Ebola Virus Disease",
   epi_dist = "offspring distribution",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 


### PR DESCRIPTION
This PR updates the {superspreading} package to use the latest function and class names from the {epiparameter} package (a suggested dependency of {superspreading}). 

Since epiverse-trace/epiparameter#360 the `<epidist>` class was renamed `<epiparameter>` (see epiverse-trace/epiparameter#325). This came with functions that used the previous naming being removed, and `epidist_db()` became deprecated and replaced by `epiparameter_db()`.

This PR replaces the use of `epidist_db()` with `epiparameter_db()`, renames `get_epidist_params()` to `get_epiparameter_params()` and replaces assertions that check the class from `<epidist>` to `<epiparameter>`. Error messages are updated, as is function documentation.

This is not a breaking change to {superspreading} as only internal functions are renamed or have arguments changed, and error messages are the only user-facing change. The vignettes are updated to call `epiparameter_db()`.