### PR TITLE
Update pkgdown mode and vignettes output

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -131,19 +131,6 @@ references:
   year: '2024'
   doi: 10.32614/CRAN.package.knitr
 - type: software
-  title: bookdown
-  abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
-  notes: Suggests
-  url: https://pkgs.rstudio.com/bookdown/
-  repository: https://CRAN.R-project.org/package=bookdown
-  authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2024'
-  doi: 10.32614/CRAN.package.bookdown
-- type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
   notes: Suggests
@@ -236,7 +223,7 @@ references:
   authors:
   - family-names: Ooms
     given-names: Jeroen
-    email: jeroen@berkeley.edu
+    email: jeroenooms@gmail.com
     orcid: https://orcid.org/0000-0002-4035-0289
   - family-names: Hester
     given-names: Jim

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,7 +72,6 @@ Suggests:
     epiparameter,
     fitdistrplus,
     knitr,
-    bookdown,
     rmarkdown,
     ggplot2,
     spelling,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,7 @@ template:
     font_weight_base : 300
 
 development:
-  mode: auto
+  mode: unreleased
 
 reference:
   - title: Offspring distributions

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,7 +3,6 @@ Althaus
 Barré
 Boëlle
 Boesmans
-bookdown
 bpmodels
 bw
 Camacho

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -51,7 +51,7 @@ The aim is to restrict the number of dependencies to a minimal required set for 
 
 {stats} is distributed with the R language so is viewed as a lightweight dependency, that should already be installed on a user's machine if they have R. {checkmate} is an input checking package widely used across Epiverse-TRACE packages.
 
-Suggested dependencies (not including package documentation ({knitr}, {bookdown}, {rmarkdown}), testing ({spelling} and {testthat}), and plotting ({ggplot2})) are: [{epiparameter}](https://github.com/epiverse-trace/epiparameter), used to easily access epidemiological parameters from the package's library, and [{fitdistrplus}](https://CRAN.R-project.org/package=fitdistrplus), used for model fitting methods.
+Suggested dependencies (not including package documentation ({knitr}, {rmarkdown}), testing ({spelling} and {testthat}), and plotting ({ggplot2})) are: [{epiparameter}](https://github.com/epiverse-trace/epiparameter), used to easily access epidemiological parameters from the package's library, and [{fitdistrplus}](https://CRAN.R-project.org/package=fitdistrplus), used for model fitting methods.
 
 ## Contribute
 

--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -97,7 +97,7 @@ to only include those with a single initial infection seeding transmission (`a =
 homogeneity <- subset(epidemic_params, num_init_infect == 1)
 ```
 
-```{r, plot-dispersion, class.source = 'fold-hide', fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from @kucharskiEarlyDynamicsTransmission2020 figure 3A.", fig.width = 8, fig.height = 5}
+```{r, plot-dispersion, fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from @kucharskiEarlyDynamicsTransmission2020 figure 3A.", fig.width = 8, fig.height = 5}
 # plot probability of epidemic across dispersion
 ggplot(data = homogeneity) +
   geom_ribbon(
@@ -140,7 +140,7 @@ introductions, the higher the chance one will lead to an epidemic.
 introductions <- subset(epidemic_params, k == 0.5)
 ```
 
-```{r, plot-introductions, class.source = 'fold-hide', fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from Kucharski et al. (2020) figure 3B.", fig.width = 8, fig.height = 5}
+```{r, plot-introductions, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from Kucharski et al. (2020) figure 3B.", fig.width = 8, fig.height = 5}
 # plot probability of epidemic across introductions
 ggplot(data = introductions) +
   geom_pointrange(
@@ -161,7 +161,7 @@ ggplot(data = introductions) +
 
 Different levels of heterogeneity in transmission will produce different probabilities of epidemics.
 
-```{r, plot-introductions-multi-k, class.source = 'fold-hide', fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. Different values of dispersion are plotted to show the effect of increased transmission variability on an epidemic establishing", fig.width = 8, fig.height = 5}
+```{r, plot-introductions-multi-k, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. Different values of dispersion are plotted to show the effect of increased transmission variability on an epidemic establishing", fig.width = 8, fig.height = 5}
 # plot probability of epidemic across introductions for multiple k
 ggplot(data = epidemic_params) +
   geom_point(
@@ -213,7 +213,7 @@ prob_extinct <- apply(extinction_params, 1, function(x) {
 extinction_params <- cbind(extinction_params, prob_extinct)
 ```
 
-```{r, plot-extinction, class.source = 'fold-hide', fig.cap="The probability that an infectious disease will go extinct for a given value of $R$ and $k$. This is calculated using `probability_extinct()` function. This plot is reproduced from @lloyd-smithSuperspreadingEffectIndividual2005 figure 2B.", fig.width = 8, fig.height = 5}
+```{r, plot-extinction, fig.cap="The probability that an infectious disease will go extinct for a given value of $R$ and $k$. This is calculated using `probability_extinct()` function. This plot is reproduced from @lloyd-smithSuperspreadingEffectIndividual2005 figure 2B.", fig.width = 8, fig.height = 5}
 # plot probability of extinction across R for multiple k
 ggplot(data = extinction_params) +
   geom_point(
@@ -308,7 +308,7 @@ prob_contain <- apply(contain_params, 1, function(x) {
 contain_params <- cbind(contain_params, prob_contain)
 ```
 
-```{r, plot-containment, class.source = 'fold-hide', fig.cap="The probability that an outbreak will be contained (i.e. not exceed 100 cases) for a variety of population-level control measures. The probability of containment is calculated using `probability_contain()`. This plot is reproduced from Lloyd-Smith et al. (2005) figure 3C.", fig.width = 8, fig.height = 5}
+```{r, plot-containment, fig.cap="The probability that an outbreak will be contained (i.e. not exceed 100 cases) for a variety of population-level control measures. The probability of containment is calculated using `probability_contain()`. This plot is reproduced from Lloyd-Smith et al. (2005) figure 3C.", fig.width = 8, fig.height = 5}
 # plot probability of epidemic across introductions for multiple k
 ggplot(data = contain_params) +
   geom_point(

--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -1,9 +1,7 @@
 ---
 title: "Epidemic Risk"
 subtitle: "Superspreading on policy, decision making and control measures"
-output: 
-  bookdown::html_vignette2:
-    code_folding: show
+output: rmarkdown::html_vignette
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -4,8 +4,6 @@ subtitle: "Superspreading on policy, decision making and control measures"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-   as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -74,7 +74,7 @@ geom_fit <- fitdist(data = all_cases, distr = "geom")
 nbinom_fit <- fitdist(data = all_cases, distr = "nbinom")
 ```
 
-```{r, fit-table, class.source = 'fold-hide'}
+```{r, fit-table}
 model_tbl <- ic_tbl(pois_fit, geom_fit, nbinom_fit)
 col.names <- gsub(
   pattern = "^Delta", replacement = "$\\\\Delta$", x = colnames(model_tbl)
@@ -130,7 +130,7 @@ nbinom_data <- data.frame(
 )
 ```
 
-```{r, plot-nbinom, class.source = 'fold-hide', fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial with the maximum likelihood estimates when fit to the empirical data (points and line). This plot is reproduced from Althaus (2015) figure 1.", fig.width = 8, fig.height = 5}
+```{r, plot-nbinom, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial with the maximum likelihood estimates when fit to the empirical data (points and line). This plot is reproduced from Althaus (2015) figure 1.", fig.width = 8, fig.height = 5}
 # make plot
 ggplot(data = nbinom_data) +
   geom_col(
@@ -247,7 +247,7 @@ poisweibull_fit <- fitdist(
 )
 ```
 
-```{r, fit-extra-table, class.source = 'fold-hide'}
+```{r, fit-extra-table}
 model_tbl <- ic_tbl(
   pois_fit, geom_fit, nbinom_fit, poislnorm_fit, poisweibull_fit
 )
@@ -287,7 +287,7 @@ dist_compare_data <- data.frame(
 )
 ```
 
-```{r, plot-dists, class.source = 'fold-hide', fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial (orange) and poisson-Weibull (pink) with the maximum likelihood estimates when fit to the empirical data (points and line).", fig.width = 8, fig.height = 5}
+```{r, plot-dists, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial (orange) and poisson-Weibull (pink) with the maximum likelihood estimates when fit to the empirical data (points and line).", fig.width = 8, fig.height = 5}
 # make plot
 ggplot(data = dist_compare_data) +
   geom_col(

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -3,8 +3,6 @@ title: "Estimate individual-level transmission"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-   as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Estimate individual-level transmission"
-output: 
-  bookdown::html_vignette2:
-    code_folding: show
+output: rmarkdown::html_vignette
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -3,8 +3,6 @@ title: "Outbreaks in heterogeneous networks"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-   as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Outbreaks in heterogeneous networks"
-output: 
-  bookdown::html_vignette2:
-    code_folding: show
+output: rmarkdown::html_vignette
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -75,7 +75,7 @@ res <- reshape(
 )
 ```
 
-```{r, plot-zika-r, class.source = 'fold-hide', fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with mean duration of infection on the x-axis and transmission probability per sexual partner on the y-axis. The line shows the points that $R_0$ is equal to one. Both axes are plotted on a natural log scale. This plot is similar to Figure 1 from @yakobLowRiskSexuallytransmitted2016, but is plotted as a heatmap and without annotation.", fig.width = 8, fig.height = 5}
+```{r, plot-zika-r, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with mean duration of infection on the x-axis and transmission probability per sexual partner on the y-axis. The line shows the points that $R_0$ is equal to one. Both axes are plotted on a natural log scale. This plot is similar to Figure 1 from @yakobLowRiskSexuallytransmitted2016, but is plotted as a heatmap and without annotation.", fig.width = 8, fig.height = 5}
 ggplot(data = res) +
   geom_tile(
     mapping = aes(
@@ -140,7 +140,7 @@ res <- reshape(
 )
 ```
 
-```{r, plot-mpox, class.source = 'fold-hide', fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with secondary attack rate on the x-axis and reproduction number ($R_0$) on the y-axis. This plot is similar to Figure 2A from @endoHeavytailedSexualContact2022.", fig.width = 8, fig.height = 5}
+```{r, plot-mpox, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with secondary attack rate on the x-axis and reproduction number ($R_0$) on the y-axis. This plot is similar to Figure 2A from @endoHeavytailedSexualContact2022.", fig.width = 8, fig.height = 5}
 ggplot(data = res) +
   geom_line(mapping = aes(x = beta, y = R, colour = group)) +
   geom_hline(mapping = aes(yintercept = 1)) +

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -3,8 +3,6 @@ title: "Getting started with {superspreading}"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Getting started with {superspreading}"
-output: 
-  bookdown::html_vignette2:
-    code_folding: show
+output: rmarkdown::html_vignette
 bibliography: references.json
 link-citations: true
 vignette: >


### PR DESCRIPTION
This PR updates the vignettes to use `rmarkdown::html_document()` rather than `bookdown::html_document2()` due to issues with compatibility after the release of {pkgdown} v2.1.0. 

As a result of the new vignette output the `as_is: true` has been removed, as has code folding which is not an option with `rmarkdown::html_document()`. 

The `development: mode` has been changed in `_pkgdown.yml` to `unreleased` from `auto` until the package is on CRAN (epiverse-trace/blueprints#100).

As {bookdown} is no longer used by the package it is removed from `Suggests` in the `DESCRIPTION`. 