### PR TITLE
Package infrastructure updates for v0.3.0 release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^doc$
 ^Meta$
 ^CITATION\.cff$
+^tools$

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,22 @@
+repository:
+  # https://probot.github.io/apps/settings/
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  default_branch: main
+  delete_branch_on_merge: true
+  # has_discussions: false
+  has_issues: true
+  # has_projects: false
+  # has_wiki: false
+  # private: false
+branches:
+  - name: main
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 0 # (1-6; optionally 0)
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: false
+      required_status_checks:
+        strict: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,11 +63,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      # Exists since R 4.3.0 but `false` by default
-      _R_CHECK_LENGTH_COLON_: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/dependency-change.yaml
+++ b/.github/workflows/dependency-change.yaml
@@ -52,6 +52,12 @@ jobs:
 
             message("Dependencies have changed! Analyzing...")
 
+            if (nrow(deps_added) > 0) {
+              nudge <- "Reach out on slack (`#code-review` or `#help` channels) to double check if there are base R alternatives to the new dependencies.\n"
+            } else {
+              nudge <- ""
+            }
+
             msg <- glue::glue(
               .sep = "\n",
               "This pull request:",
@@ -60,7 +66,8 @@ jobs:
               "- Removes {nrow(deps_removed)} existing dependencies (direct and indirect)",
               "- Removes {length(unique(deps_removed$sysreqs))} existing system dependencies",
               "",
-              "(Note that results may be inacurrate if you branched from an outdated version of the target branch.)"
+              nudge,
+              "(Note that results may be inaccurate if you branched from an outdated version of the target branch.)"
             )
 
             message("Posting results as a pull request comment.")

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -34,6 +34,7 @@ jobs:
             any::gh
             any::lintr
             any::purrr
+            any::cyclocomp
             epiverse-trace/etdev
           needs: check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -54,7 +54,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -71,9 +71,14 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
+      - name: Check website links
+        uses: untitaker/hyperlink@0.1.32
+        with:
+          args: docs/
+
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.6.8
         with:
           # We clean on releases because we want to remove old vignettes,
           # figures, etc. that have been deleted from the `main` branch.

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -49,7 +49,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -32,6 +32,8 @@ concurrency:
 
 name: test-coverage
 
+permissions: read-all
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
@@ -39,7 +41,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -47,9 +49,37 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -6,9 +6,7 @@
 on:
   push:
     branches:
-      # This may seem like a no-op but it prevents triggering on tags.
-      # We use '**' rather '*' to accomodate names like 'dev/branch-1'
-      - '**'
+      - main
     paths:
       - DESCRIPTION
       - inst/CITATION
@@ -16,13 +14,9 @@ on:
   workflow_dispatch:
 
 name: Update CITATION.cff
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-citation-cff:
@@ -30,7 +24,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -53,12 +47,13 @@ jobs:
           cff_write(keys = mykeys)
 
         shell: Rscript {0}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update `CITATION.cff`
+          title: Update `CITATION.cff`
+          body: |
+            This pull request updates the citation file, ensuring all authors are credited and there are no discrepancies.
 
-      - name: Commit results
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add CITATION.cff
-          git commit -m 'Update CITATION.cff' || echo "No changes to commit"
-          git pull --rebase origin ${{ github.ref.name }}
-          git push origin || echo "No changes to commit"
+            Please verify the changes before merging.
+          branch: update-citation-cff

--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -1,0 +1,37 @@
+name: Update copyright year(s) in license file
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 1 1 *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: |
+            LICENSE.md
+          prBody: >
+           This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+
+           ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            path: |
+              LICENSE
+            prBody: >
+             This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+
+             ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
+            transform: (?<=YEAR:\s)(?<from>\d{4})?-?(\d{4})?

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 # RStudio files
 .Rproj.user/
 
+# vignette building
+/doc/
+/Meta/
+
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
@@ -47,7 +51,7 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
-R/.DS_Store
+
+# macOS hidden files
+.DS_Store
 inst/doc
-/doc/
-/Meta/

--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: all_linters(
     packages = c("lintr", "etdev"),
+    pipe_consistency_linter(pipe = "%>%"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,

--- a/R/dev-utils.R
+++ b/R/dev-utils.R
@@ -3,6 +3,7 @@ release_bullets <- function() { # nocov start
   c(
     "Run `goodpractice::gp()`",
     "Review [WORDLIST](https://docs.cran.dev/spelling#wordlist)",
-    "Check if `# nolint` comments are still needed with recent lintr releases"
+    "Check if `# nolint` comments are still needed with recent lintr releases",
+    "All contributors to this release are acknowledged in some way"
   )
 } # nocov end

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ probability_epidemic(
   k = param_index$estimate[["k"]],
   num_init_infect = initial_infections
 )
-#> [1] 0.9995781
+#> [1] 0.9995741
 
 # Probability of an epidemic using k estimated from non-index cases
 probability_epidemic(
@@ -197,18 +197,18 @@ By contributing to this project, you agree to abide by its terms.
 citation("superspreading")
 #> To cite package 'superspreading' in publications use:
 #> 
-#>   Lambert J, Kucharski A (2024). _superspreading: Estimate
+#>   Lambert J, Kucharski A, Adam D (2024). _superspreading: Estimate
 #>   Individual-Level Variation in Transmission_. R package version
-#>   0.1.0.9000, https://epiverse-trace.github.io/superspreading/,
+#>   0.2.0.9000, https://epiverse-trace.github.io/superspreading/,
 #>   <https://github.com/epiverse-trace/superspreading>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
 #>     title = {superspreading: Estimate Individual-Level Variation in Transmission},
-#>     author = {Joshua W. Lambert and Adam Kucharski},
+#>     author = {Joshua W. Lambert and Adam Kucharski and Dillon C. Adam},
 #>     year = {2024},
-#>     note = {R package version 0.1.0.9000, 
+#>     note = {R package version 0.2.0.9000, 
 #> https://epiverse-trace.github.io/superspreading/},
 #>     url = {https://github.com/epiverse-trace/superspreading},
 #>   }
@@ -230,7 +230,8 @@ This project has some overlap with other R packages:
 
 ## References
 
-<div id="refs" class="references csl-bib-body hanging-indent">
+<div id="refs" class="references csl-bib-body hanging-indent"
+entry-spacing="0">
 
 <div id="ref-althausEbolaSuperspreading2015" class="csl-entry">
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,8 +3,8 @@
 #
 # Where should you do additional test configuration?
 # Learn more about the roles of various files in:
-# * https://r-pkgs.org/tests.html
-# * https://testthat.r-lib.org/reference/test_package.html#special-files
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
 library(superspreading)

--- a/tools/check.env
+++ b/tools/check.env
@@ -5,7 +5,14 @@ _R_CHECK_PKG_SIZES_=false
 _R_CHECK_RD_XREFS_=false
 
 # Do not report if package requires GNU make
-_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=false
+# https://github.com/epiverse-trace/packagetemplate/issues/119
+# https://github.com/r-lib/rcmdcheck/pull/219
+_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=true
 
 # Do not check non-ASCII strings in datasets
 _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_=true
+
+# Exists since R 4.3.0 but `false` by default.
+# https://bugs.r-project.org/show_bug.cgi?id=18419
+# Warn when using : with an element of length more than one
+_R_CHECK_LENGTH_COLON_=true


### PR DESCRIPTION
This PR updates the package infrastructure before the upcoming v0.3.0 release, including:
* GitHub actions workflow files
* add a new workflow for updating the copyright year
* `.gitignore` and `.Rbuildignore` files
* `check.env` file 
* `.lintr` file 
* `release_bullets()` 

This syncs the updates in {packagetemplate} with {superspreading}.