### PR TITLE
Update {epiparameter} usage

### DIFF
--- a/tests/testthat/test-probability_contain.R
+++ b/tests/testthat/test-probability_contain.R
@@ -96,7 +96,7 @@ test_that("probability_contain works with <epiparameter>", {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "SARS",
-      epi_dist = "offspring distribution",
+      epi_name = "offspring distribution",
       author = "Lloyd-Smith",
       single_epiparameter = TRUE
     )

--- a/tests/testthat/test-probability_epidemic.R
+++ b/tests/testthat/test-probability_epidemic.R
@@ -99,7 +99,7 @@ test_that("probability_epidemic works with <epiparameter>", {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "SARS",
-      epi_dist = "offspring distribution",
+      epi_name = "offspring distribution",
       author = "Lloyd-Smith",
       single_epiparameter = TRUE
     )

--- a/tests/testthat/test-proportion_cluster_size.R
+++ b/tests/testthat/test-proportion_cluster_size.R
@@ -89,7 +89,7 @@ test_that("proportion_cluster_size works with <epiparameter>", {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "SARS",
-      epi_dist = "offspring distribution",
+      epi_name = "offspring distribution",
       author = "Lloyd-Smith",
       single_epiparameter = TRUE
     )

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -183,7 +183,7 @@ test_that("proportion_transmission works with <epiparameter>", {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "SARS",
-      epi_dist = "offspring distribution",
+      epi_name = "offspring distribution",
       author = "Lloyd-Smith",
       single_epiparameter = TRUE
     )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,7 +2,7 @@ if (requireNamespace("epiparameter", quietly = TRUE)) {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "SARS",
-      epi_dist = "offspring distribution",
+      epi_name = "offspring distribution",
       author = "Lloyd-Smith",
       single_epiparameter = TRUE
     )
@@ -29,7 +29,7 @@ test_that("get_param fails as expected with incorrect parameters", {
   od <- suppressMessages(
     epiparameter::epiparameter_db(
       disease = "COVID-19",
-      epi_dist = "incubation period",
+      epi_name = "incubation period",
       author = "Linton",
       single_epiparameter = TRUE
     )

--- a/vignettes/proportion_transmission.Rmd
+++ b/vignettes/proportion_transmission.Rmd
@@ -88,7 +88,7 @@ To show the proportion of transmission using both methods we can load the estima
 ```{r, load-offspring-dist}
 library(epiparameter)
 offspring_dists <- epiparameter_db(
-  epi_dist = "offspring distribution"
+  epi_name = "offspring distribution"
 )
 ```
 

--- a/vignettes/superspreading.Rmd
+++ b/vignettes/superspreading.Rmd
@@ -119,12 +119,12 @@ diseases and evaluate how likely they are to cause epidemics.
 ```{r, epiparam}
 sars <- epiparameter_db(
   disease = "SARS",
-  epi_dist = "offspring distribution",
+  epi_name = "offspring distribution",
   single_epiparameter = TRUE
 )
 evd <- epiparameter_db(
   disease = "Ebola Virus Disease",
-  epi_dist = "offspring distribution",
+  epi_name = "offspring distribution",
   single_epiparameter = TRUE
 )
 ```


### PR DESCRIPTION
This PR updates the argument names of `epiparameter_db()` from the {epiparameter} package after breaking changes were made in epiverse-trace/epiparameter#390.