### PR TITLE
Fix math rendering on pkgdown site using KaTeX headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ We are also pleased to welcome Dillon Adam (@dcadam) as a new package author for
 
 * The proportions output of `proportion_*()` functions are now formatted to significant figures rather than rounding to prevent small values being rounded to zero (#102).
 * Improve input checking, error messages and edge case handling for functions (#102).
-* Vignettes now use `rmarkdown::html_vignette` instead of `bookdown::html_vignette2` and `as_is: true` has been removed due to changes to {pkgdown} in v2.1.0. {bookdown} has been removed as a suggested package and code folding is removed from vignettes.
+* Vignettes now use `rmarkdown::html_vignette` instead of `bookdown::html_vignette2` and `as_is: true` has been removed due to changes to {pkgdown} in v2.1.0. {bookdown} has been removed as a suggested package and code folding is removed from vignettes. KaTeX headers have been added to `_pkgdown.yml` for correct math rendering (#104 & #109).
 * The `get_epidist_params()` internal function has been renamed `get_epiparameter_params()` since {epiparameter} renamed the `<epidist>` class to `<epiparameter>` (#100).
 
 ## Bug fixes

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,10 @@
 url: https://epiverse-trace.github.io/superspreading
 template:
+  includes:
+    in_header: |
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+      <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+      <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
   package: epiversetheme
   bslib:
     font_weight_base : 300


### PR DESCRIPTION
This PR resolves an issue with the rendering of equations on the {superspreading} pkgdown website by including the KaTeX headers. Solution from https://github.com/r-lib/pkgdown/issues/2704#issuecomment-2307055568.