### PR TITLE
Back-date starting copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2024-2025
+YEAR: 2022-2025
 COPYRIGHT HOLDER: superspreading authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024-2025 superspreading authors
+Copyright (c) 2022-2025 superspreading authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR updates the `LICENSE` files to back-date the earliest year of the copyright year range to the year the project started. This is due to the GHA workflow automatically updating the copyright year using a year range rather than the current year as was previously being used.