### PR TITLE
Set pkgdown `development: mode` to `auto` since CRAN release

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,7 +10,7 @@ template:
     font_weight_base : 300
 
 development:
-  mode: unreleased
+  mode: auto
 
 reference:
   - title: Offspring distributions


### PR DESCRIPTION
This PR updates the `development: mode` in `_pkgdown.yml` from `unreleased` to `auto`, as the per the [Epiverse-TRACE blueprints](https://epiverse-trace.github.io/blueprints/website.html) since {superspreading} is now on CRAN.