### PR TITLE
Add alt-text to vignette figures

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,5 @@
 aes
+alt
 Althaus
 Antia
 Barré

--- a/man/superspreading-package.Rd
+++ b/man/superspreading-package.Rd
@@ -6,7 +6,7 @@
 \alias{superspreading-package}
 \title{superspreading: Understand Individual-Level Variation in Infectious Disease Transmission}
 \description{
-Estimate and understand individual-level variation in transmission. Implements density and cumulative compound Poisson discrete distribution functions ('Kremer et al.' (2021) \doi{10.1038/s41598-021-93578-x}), as well as functions to calculate infectious disease outbreak statistics given epidemiological parameters on individual-level transmission; including the probability of an outbreak becoming an epidemic/extinct ('Kucharski et al.' (2020) \doi{10.1016/S1473-3099(20)30144-4}), or the cluster size statistics, e.g. what proportion of cases cause X\% of transmission ('Lloyd-Smith et al.' (2005) \doi{10.1038/nature04153}).
+Estimate and understand individual-level variation in transmission. Implements density and cumulative compound Poisson discrete distribution functions (Kremer et al. (2021) \doi{10.1038/s41598-021-93578-x}), as well as functions to calculate infectious disease outbreak statistics given epidemiological parameters on individual-level transmission; including the probability of an outbreak becoming an epidemic/extinct (Kucharski et al. (2020) \doi{10.1016/S1473-3099(20)30144-4}), or the cluster size statistics, e.g. what proportion of cases cause X\% of transmission (Lloyd-Smith et al. (2005) \doi{10.1038/nature04153}).
 }
 \seealso{
 Useful links:

--- a/vignettes/emergence.Rmd
+++ b/vignettes/emergence.Rmd
@@ -12,7 +12,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -53,7 +55,18 @@ prob_emerge <- apply(
 res <- cbind(params, prob_emerge = prob_emerge)
 ```
 
-```{r plot-prob-emerge, fig.width = 8, fig.height = 5}
+```{r plot-prob-emerge}
+#| fig.alt: >
+#|   Line plot showing the probability of emergence of a pathogen as a function
+#|   of the basic reproduction number (R0) of the introduced pathogen. The
+#|   x-axis represents the R0 of the introduced pathogen, ranging from 0 to
+#|   1.2. The y-axis shows the probability of emergence on a logarithmic scale
+#|   from 1e-05 to 1. Lines vary by mutation rate (green for 0.001 and black
+#|   for 0.1) and by mutant pathogen R0 (dotted for R0 = 1.2, dashed for R0 =
+#|   1.5, solid for R0 = 1000). For both mutation rates, the probability of
+#|   emergence increases with the R0 of the introduced pathogen and with the
+#|   R0 of the mutant. Higher mutation rates and higher mutant R0s lead to
+#|   higher probabilities of emergence.
 ggplot(data = res) +
   geom_line(
     mapping = aes(
@@ -116,7 +129,19 @@ prob_emerge <- apply(
 res <- cbind(params, prob_emerge = prob_emerge)
 ```
 
-```{r plot-prob-emerge-multi-type, fig.width = 8, fig.height = 5}
+```{r plot-prob-emerge-multi-type}
+#| fig.alt: >
+#|   Line plot showing the probability of emergence of a pathogen as a function
+#|   of the basic reproduction number (R0) of the introduced pathogen, with
+#|   varying numbers of intermediate mutants before reaching the fully-evolved
+#|   mutant. The x-axis represents the R0 of the introduced pathogen (ranging
+#|   from 0 to 1.2), and the y-axis shows the probability of emergence on a
+#|   logarithmic scale from 1e-05 to 1. Lines represent different numbers of
+#|   intermediate mutants: red for 0, blue for 1, green for 2, purple for 3,
+#|   and orange for 4. As the number of required intermediate mutants
+#|   increases, the probability of emergence decreases across all R0 values.
+#|   All curves rise with increasing R0, and converge at higher R0 values near
+#|   1.2.
 ggplot(data = res) +
   geom_line(
     mapping = aes(

--- a/vignettes/epidemic_risk.Rmd
+++ b/vignettes/epidemic_risk.Rmd
@@ -13,7 +13,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -97,7 +99,20 @@ to only include those with a single initial infection seeding transmission (`a =
 homogeneity <- subset(epidemic_params, num_init_infect == 1)
 ```
 
-```{r, plot-dispersion, fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from @kucharskiEarlyDynamicsTransmission2020 figure 3A.", fig.width = 8, fig.height = 5}
+```{r, plot-dispersion, fig.cap="The probability that an initial infection (introduction) will cause a sustained outbreak (transmission chain). The dispersion of the individual-level transmission is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from @kucharskiEarlyDynamicsTransmission2020 figure 3A."}
+#| fig.alt: >
+#|   A graph showing the relationship between extent of homogeneity in
+#|   transmission (x-axis, from 0 to 1) and probability of a large outbreak
+#|   (y-axis, from 0 to 1). A black curved line shows an increasing
+#|   relationship, starting near 0 and rising to 0.57, with the
+#|   curve flattening as homogeneity increases. A grey shaded area around the
+#|   line indicates confidence intervals, widening toward higher homogeneity
+#|   values. Two vertical dashed lines mark specific diseases: SARS at 0.2
+#|   extent of homogeneity (corresponding to a 0.23 probability of large
+#|   outbreak), and MERS at 0.4 extent of homogeneity (corresponding to 0.37
+#|   probability of large outbreak). The graph illustrates that diseases
+#|   with more homogeneous transmission patterns have higher probabilities of
+#|   causing large outbreaks.
 # plot probability of epidemic across dispersion
 ggplot(data = homogeneity) +
   geom_ribbon(
@@ -140,7 +155,20 @@ introductions, the higher the chance one will lead to an epidemic.
 introductions <- subset(epidemic_params, k == 0.5)
 ```
 
-```{r, plot-introductions, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from Kucharski et al. (2020) figure 3B.", fig.width = 8, fig.height = 5}
+```{r, plot-introductions, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. This plot is reproduced from Kucharski et al. (2020) figure 3B."}
+#| fig.alt: >
+#|   A scatter plot showing the relationship between the number of
+#|   introductions of an infectious disease (x-axis, ranging from 0 to 10) and
+#|   the probability of large outbreak (y-axis, ranging from 0 to 1). Each
+#|   point estimate has vertical error bars showing confidence
+#|   intervals. The plot shows a clear increasing trend: starting at 0
+#|   introductions with 0% probability of large outbreak, rising to 42% at 1
+#|   introduction, 66% at 2 introductions, 81% at 3 introductions, 89% at 4
+#|   introductions, 93% at 5 introductions, 96% at 6 introductions, and
+#|   plateauing near 99% for 7-10 introductions. The confidence intervals are
+#|   widest at intermediate values (1-5 introductions). The pattern
+#|   demonstrates the more introduction increase the probability of a large
+#|   outbreak but has minimal impact once the probability approaches 1.
 # plot probability of epidemic across introductions
 ggplot(data = introductions) +
   geom_pointrange(
@@ -161,7 +189,21 @@ ggplot(data = introductions) +
 
 Different levels of heterogeneity in transmission will produce different probabilities of epidemics.
 
-```{r, plot-introductions-multi-k, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. Different values of dispersion are plotted to show the effect of increased transmission variability on an epidemic establishing", fig.width = 8, fig.height = 5}
+```{r, plot-introductions-multi-k, fig.cap="The probability that an a number of introduction events will cause a sustained outbreak (transmission chain). The number of disease introductions is plotted on the x-axis and probability of outbreak -- calculated using `probability_epidemic()` -- is on the y-axis. Different values of dispersion are plotted to show the effect of increased transmission variability on an epidemic establishing"}
+#| fig.alt: >
+#|   A scatter plot showing the relationship between the number of
+#|   introductions (x-axis, ranging from 0 to 10) and the probability of a
+#|   large outbreak (y-axis, ranging from 0 to 1). Points are coloured
+#|   according to a dispersion parameter (k) ranging from 0 (purple) to
+#|   1.00 (yellow), as shown in the legend. The plot demonstrates that higher
+#|   dispersion values (yellow and green points) consistently show higher
+#|   probabilities of large outbreaks across all numbers of introductions. For
+#|   any given number of introductions, there is a clear gradient from low
+#|   outbreak probability (purple points at bottom) to high outbreak
+#|   probability (yellow points at top). The relationship shows that both the
+#|   number of introductions and the dispersion parameter influence outbreak
+#|   probability, with the steepest increases occurring between 1-4
+#|   introductions.
 # plot probability of epidemic across introductions for multiple k
 ggplot(data = epidemic_params) +
   geom_point(
@@ -213,7 +255,20 @@ prob_extinct <- apply(extinction_params, 1, function(x) {
 extinction_params <- cbind(extinction_params, prob_extinct)
 ```
 
-```{r, plot-extinction, fig.cap="The probability that an infectious disease will go extinct for a given value of $R$ and $k$. This is calculated using `probability_extinct()` function. This plot is reproduced from @lloyd-smithSuperspreadingEffectIndividual2005 figure 2B.", fig.width = 8, fig.height = 5}
+```{r, plot-extinction, fig.cap="The probability that an infectious disease will go extinct for a given value of $R$ and $k$. This is calculated using `probability_extinct()` function. This plot is reproduced from @lloyd-smithSuperspreadingEffectIndividual2005 figure 2B."}
+#| fig.alt: >
+#|   A scatter plot showing the relationship between the reproduction number
+#|   (R) (x-axis, ranging from 0 to 5) and the probability of extinction
+#|   (y-axis, ranging from 0 to 1). Points are discretely coloured
+#|   according to a dispersion parameter (k) ranging from 0.01 (purple) to
+#|   infinite (yellow), with intermediate values of 0.1, 0.5, 1 and 4, as shown
+#|   in the legend. The plot demonstrates that higher dispersion values (yellow
+#|   and green points) consistently show lower probabilities of extinction
+#|   across all reproduction numbers greater than 1. All points for
+#|   reproduction numbers below 1 have a probability of extinction at 1.
+#|   The probability of extinction declines sharply in an exponential-like
+#|   fashion for higher dispersion values, whereas smaller values of dispersion
+#|   have a more gradual decline with higher reproduction numbers.
 # plot probability of extinction across R for multiple k
 ggplot(data = extinction_params) +
   geom_point(
@@ -308,7 +363,18 @@ prob_contain <- apply(contain_params, 1, function(x) {
 contain_params <- cbind(contain_params, prob_contain)
 ```
 
-```{r, plot-containment, fig.cap="The probability that an outbreak will be contained (i.e. not exceed 100 cases) for a variety of population-level control measures. The probability of containment is calculated using `probability_contain()`. This plot is reproduced from Lloyd-Smith et al. (2005) figure 3C.", fig.width = 8, fig.height = 5}
+```{r, plot-containment, fig.cap="The probability that an outbreak will be contained (i.e. not exceed 100 cases) for a variety of population-level control measures. The probability of containment is calculated using `probability_contain()`. This plot is reproduced from Lloyd-Smith et al. (2005) figure 3C."}
+#| fig.alt: >
+#|   A scatter plot showing the relationship between the strength of outbreak
+#|   control measures (c) (x-axis, ranging from 0 to 1) and the probability of
+#|   containment (y-axis, ranging from 0 to 1). Points are discretely coloured
+#|   according to a dispersion parameter (k) ranging from 0.1 (purple) to
+#|   infinite (yellow), with intermediate values of 0.5 and 1, as shown in the
+#|   legend. The plot demonstrates that the probability of outbreak containment
+#|   increases with greater control measures, with lower dispersion values
+#|   having a higher probability of containment than higher dispersion values
+#|   for each control measure value. Once control measures reach 0.7 all
+#|   dispersion values converge to a probability of containment of 1.
 # plot probability of epidemic across introductions for multiple k
 ggplot(data = contain_params) +
   geom_point(

--- a/vignettes/estimate_individual_level_transmission.Rmd
+++ b/vignettes/estimate_individual_level_transmission.Rmd
@@ -12,7 +12,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -130,8 +132,23 @@ nbinom_data <- data.frame(
 )
 ```
 
-```{r, plot-nbinom, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial with the maximum likelihood estimates when fit to the empirical data (points and line). This plot is reproduced from Althaus (2015) figure 1.", fig.width = 8, fig.height = 5}
-# make plot
+```{r, plot-nbinom, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial with the maximum likelihood estimates when fit to the empirical data (points and line). This plot is reproduced from Althaus (2015) figure 1."}
+#| fig.alt: >
+#|   A bar plot showing the frequency distribution of the number of secondary
+#|   cases (x-axis, ranging from 0 to 20) versus frequency (y-axis, ranging
+#|   from 0.0 to 0.7) from the empirical data. The distribution is heavily
+#|   right-skewed with cyan coloured bars showing that the empirical data has
+#|   a vast majority of cases (72%) produce zero secondary cases. The
+#|   frequency drops sharply for higher numbers of secondary cases,
+#|   11% producing 1 secondary case, 6% producing 2 secondary cases, and
+#|   progressively smaller percentages for higher numbers of secondary cases.
+#|   An orange line with points overlays the histogram showing the probability
+#|   mass function following the same pattern as the bars and extending across
+#|   the full range to show the match between empirical data and negative
+#|   binomial parameter estimates. The distribution illustrates the
+#|   characteristic pattern of infectious disease transmission where most
+#|   infected individuals transmit to few or no others, while a small
+#|   proportion become superspreaders responsible for many secondary infections.
 ggplot(data = nbinom_data) +
   geom_col(
     mapping = aes(x = x, y = prop_num_cases),
@@ -287,8 +304,22 @@ dist_compare_data <- data.frame(
 )
 ```
 
-```{r, plot-dists, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial (orange) and poisson-Weibull (pink) with the maximum likelihood estimates when fit to the empirical data (points and line).", fig.width = 8, fig.height = 5}
-# make plot
+```{r, plot-dists, fig.cap="Number of secondary cases from the empirical data (bar plot) and the density of the negative binomial (orange) and poisson-Weibull (pink) with the maximum likelihood estimates when fit to the empirical data (points and line)."}
+#| fig.alt: >
+#|   A histogram showing the frequency distribution of the number of secondary
+#|   cases (x-axis, ranging from 0 to 20) versus frequency (y-axis, ranging
+#|   from 0 to 0.7). The distribution is heavily right-skewed with cyan
+#|   coloured bars showing that the empirical data has 72% of cases produce
+#|   zero secondary cases. Two fitted distribution probability mass function
+#|   curves are overlaid: an orange line with points representing the Negative
+#|   Binomial distribution, and a yellow line with points representing the
+#|   Poisson-Weibull distribution. Both estimated curves closely follow the
+#|   observed data pattern. The frequency drops sharply from 0 secondary cases
+#|   (0.72 frequency) to 1 secondary case (0.11 frequency), then continues to
+#|   decline for higher numbers of secondary cases. This pattern illustrates
+#|   the characteristic overdispersion in infectious disease transmission
+#|   where most individuals infect few or no others, while a small proportion
+#|   become superspreaders.
 ggplot(data = dist_compare_data) +
   geom_col(
     mapping = aes(x = x, y = prop_num_cases),

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -12,7 +12,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -75,7 +77,21 @@ res <- reshape(
 )
 ```
 
-```{r, plot-zika-r, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with mean duration of infection on the x-axis and transmission probability per sexual partner on the y-axis. The line shows the points that $R_0$ is equal to one. Both axes are plotted on a natural log scale. This plot is similar to Figure 1 from @yakobLowRiskSexuallytransmitted2016, but is plotted as a heatmap and without annotation.", fig.width = 8, fig.height = 5}
+```{r, plot-zika-r, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with mean duration of infection on the x-axis and transmission probability per sexual partner on the y-axis. The line shows the points that $R_0$ is equal to one. Both axes are plotted on a natural log scale. This plot is similar to Figure 1 from @yakobLowRiskSexuallytransmitted2016, but is plotted as a heat map and without annotation."}
+#| fig.alt: >
+#|   Two side-by-side heat maps showing the relationship between mean duration
+#|   of infectiousness (x-axis, logarithmic scale from 0.01 to 10) and Zika
+#|   virus transmission probability per sexual partners (y-axis, logarithmic
+#|   scale from 0.01 to 1). Both plots use a gradient colour scale representing
+#|   R values from 0.0001 (purple) to 10 (yellow). The left panel
+#|   shows the unadjusted R values and the right panel shows adjusted R values.
+#|   Both heat maps display similar patterns with higher R values (brighter
+#|   colours) appearing in the upper right regions where both duration of
+#|   infectiousness and transmission probability are high. A black diagonal
+#|   line runs across both plots showing the point R is equal to 1. The
+#|   adjusted R panel shows higher values overall compared to the unadjusted R
+#|   panel, with more yellow regions in the top right corner indicating higher
+#|   transmission potential.
 ggplot(data = res) +
   geom_tile(
     mapping = aes(
@@ -140,7 +156,20 @@ res <- reshape(
 )
 ```
 
-```{r, plot-mpox, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with secondary attack rate on the x-axis and reproduction number ($R_0$) on the y-axis. This plot is similar to Figure 2A from @endoHeavytailedSexualContact2022.", fig.width = 8, fig.height = 5}
+```{r, plot-mpox, fig.cap="The reproduction number using the unadjusted and adjusted calculation -- calculated using `calc_network_R()` -- with secondary attack rate on the x-axis and reproduction number ($R_0$) on the y-axis. This plot is similar to Figure 2A from @endoHeavytailedSexualContact2022."}
+#| fig.alt: >
+#|   A line graph showing the relationship between Secondary Attack Rate (SAR)
+#|   on the x-axis (from 0 to 1) and reproduction number (R) on the y-axis
+#|   (logarithmic scale from 0.0001 to 1). Two curves are plotted: a red line
+#|   representing the unadjusted R values and a blue line representing adjusted
+#|   R values. Both curves start near zero at low SAR values and increase as
+#|   SAR increases, but the adjusted R (blue) line shows consistently higher
+#|   values than the unadjusted R (red) line throughout the range. The 
+#|   unadjusted R (red) curve rises more gradually, reaching approximately 0.02
+#|   at SAR = 1, while the adjusted R (blue) curve rises more steeply
+#|   initially then levels off, reaching 0.58 at SAR = 1. Both curves show the
+#|   steepest increases at low SAR values (0.00 to 0.25) before the rate of
+#|   increase diminishes at higher SAR values.
 ggplot(data = res) +
   geom_line(mapping = aes(x = beta, y = R, colour = group)) +
   geom_hline(mapping = aes(yintercept = 1)) +
@@ -159,8 +188,6 @@ ggplot(data = res) +
   theme_bw() +
   theme(legend.position = "top")
 ```
-
-
 
 ::: {.alert .alert-warning}
 _Methodological caveat_: There is a link with the theory for the main negative binomial models from the [superspreading package](https://epiverse-trace.github.io/superspreading/) here (which have a Gamma distributed mean), because the above Anderson and May formulation requires the 'true' mean and variance of the underlying static contact distribution, rather than the observed mean and variance. To give the superspreading version: in a simple branching process with fixed $R_0$ (i.e. zero variance in the individual-level reproduction number, perhaps because everyone has an identical number of contacts), the Poisson distributed number of transmissions per year measured exhibits more variation than the 'true' $R_0$ (which has zero variance). For the above STI model, taking the lifetime average deals with this problem some extent, because if we look at the sum of contacts over a large number of years, then calculate the mean per year, the observed distribution will converge as the number of years gets very large.

--- a/vignettes/heterogeneous_network_outbreaks.Rmd
+++ b/vignettes/heterogeneous_network_outbreaks.Rmd
@@ -164,7 +164,7 @@ res <- reshape(
 #|   representing the unadjusted R values and a blue line representing adjusted
 #|   R values. Both curves start near zero at low SAR values and increase as
 #|   SAR increases, but the adjusted R (blue) line shows consistently higher
-#|   values than the unadjusted R (red) line throughout the range. The 
+#|   values than the unadjusted R (red) line throughout the range. The
 #|   unadjusted R (red) curve rises more gradually, reaching approximately 0.02
 #|   at SAR = 1, while the adjusted R (blue) curve rises more steeply
 #|   initially then levels off, reaching 0.58 at SAR = 1. Both curves show the

--- a/vignettes/proportion_transmission.Rmd
+++ b/vignettes/proportion_transmission.Rmd
@@ -12,7 +12,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -174,7 +176,7 @@ get_infectious_curve <- function(R, k) {
 
 We can now reproduce Figure 1b in @lloyd-smithSuperspreadingEffectIndividual2005 using the offspring distribution parameters obtained above.
 
-```{r, fig.width=8}
+```{r}
 infect_curve <- map(offspring_dist_params %>% # nolint nested_pipe_linter
       group_split(disease), function(x) {
         get_infectious_curve(R = x$mean, k = x$dispersion) %>%
@@ -185,7 +187,22 @@ infect_curve <- map(offspring_dist_params %>% # nolint nested_pipe_linter
       })
 
 infect_curve <- do.call(rbind, infect_curve)
+```
 
+```{r}
+#| fig.alt: >
+#|   Line plot showing the expected proportion of transmission as a function of
+#|   the proportion of infectious cases (ranked), for six infectious diseases.
+#|   The x-axis shows the cumulative proportion of infectious cases (from 0 to
+#|   1), and the y-axis shows the cumulative proportion of transmission. A
+#|   black diagonal line represents a homogeneous population where each case
+#|   contributes equally to transmission. Curves above the diagonal indicate
+#|   transmission heterogeneity. The diseases are colour-coded: Ebola Virus
+#|   Disease (red), Hantavirus Pulmonary Syndrome (gold), Mpox (green),
+#|   Pneumonic Plague (cyan), SARS (blue), and Smallpox (pink). SARS shows the
+#|   highest transmission heterogeneity, with the top ~20% of cases accounting
+#|   for 88% transmission. A vertical dashed line at x = 0.2 highlights
+#|   the 20% threshold.
 ggplot(
   data = infect_curve,
   aes(x = prop_i, y = exp_t, colour = disease)
@@ -218,7 +235,7 @@ ggplot(
 
 This plot shows the variability in transmission owing to the gamma-distributed individual reproduction number ($\nu$). If we take a slice through the above plot when the proportion of infectious cases equals 0.2 (shown by the dashed line) we can calculate the proportion of transmission caused by the most infectious 20% of cases using the `proportion_tranmission(..., method = "t_20")` function. 
 
-```{r, fig.width=8}
+```{r}
 k_seq <- superspreading:::lseq(from = 0.01, to = 100, length.out = 1000) # nolint
 y <- map_dbl(
   k_seq,
@@ -230,7 +247,24 @@ y <- map_dbl(
   }
 )
 prop_t20 <- data.frame(k_seq, y)
+```
 
+```{r}
+#| fig.alt: >
+#|   A graph showing the relationship between dispersion parameter (x-axis,
+#|   logarithmic scale from 0.1 to 100) and proportion of transmission expected
+#|   from the most infectious 20% of cases (y-axis, from 0.0 to 1.0). A black
+#|   curve shows a decreasing relationship - as the dispersion parameter
+#|   increases, the proportion decreases from 1.0 to approximately 0.2. Six
+#|   infectious diseases are plotted as colored points along this curve: SARS
+#|   (blue, 0.16 dispersion, 0.88 proportion), Smallpox (magenta, 0.37
+#|   dispersion, 0.71 proportion), Mpox (green, 0.58 dispersion, 0.62
+#|   proportion), Pneumonic Plague (teal, 1.37 dispersion, 0.47 proportion),
+#|   Hantavirus Pulmonary Syndrome (yellow, 1.66 dispersion, 0.45 proportion),
+#|   and Ebola Virus Disease (red, 5.10 dispersion, 0.34 proportion). The graph
+#|   illustrates that diseases with lower dispersion parameters show greater
+#|   superspreading potential, with a smaller proportion of highly infectious
+#|   individuals responsible for most transmission.
 ggplot() +
   geom_line(data = prop_t20, mapping = aes(x = k_seq, y = y)) +
   geom_point(


### PR DESCRIPTION
This PR adds alt-text to all the figures across the package vignettes. The yaml syntax is used to add alt text in each code chunk that contains plotting.

Some vignette figures contained figure captions (`fig.cap`), these have been left in. Therefore, some figures have only alt-text, while others have alt-text and a figure caption. 

`fig.width` and `fig.height` is now set in `knitr::opts_chunk` once per vignette rather than in each code chunk that contains plotting code.