### PR TITLE
Rename `percent_transmission` to `prop_transmission` in `proportion_transmission()`

### DIFF
--- a/man/proportion_transmission.Rd
+++ b/man/proportion_transmission.Rd
@@ -8,7 +8,7 @@ transmission}
 proportion_transmission(
   R,
   k,
-  percent_transmission,
+  prop_transmission,
   method = c("p_80", "t_20"),
   simulate = FALSE,
   ...,
@@ -23,8 +23,9 @@ per infectious individual).}
 \item{k}{A \code{number} specifying the  k parameter (i.e. overdispersion in
 offspring distribution from fitted negative binomial).}
 
-\item{percent_transmission}{A \code{number} of the percentage transmission
-for which a proportion of cases has produced.}
+\item{prop_transmission}{A \code{number} of the proportion of transmission
+for which a proportion of cases has produced. Must be between 0 and 1
+(exclusive, \eqn{(0, 1)}).}
 
 \item{method}{A \code{character} string defining which method is used to calculate
 the proportion of transmission. Options are \code{"p_80"} (default) or \code{"t_20"}.
@@ -108,13 +109,13 @@ calls. The number of simulation replicates is fixed to 10\if{html}{\out{<sup>}}5
 }
 \examples{
 # example of single values of R and k
-percent_transmission <- 0.8 # 80\% of transmission
+prop_transmission <- 0.8 # 80\% of transmission
 R <- 2
 k <- 0.5
 proportion_transmission(
   R = R,
   k = k,
-  percent_transmission = percent_transmission
+  prop_transmission = prop_transmission
 )
 
 # example with multiple values of k
@@ -122,7 +123,7 @@ k <- c(0.1, 0.2, 0.3, 0.4, 0.5, 1)
 proportion_transmission(
   R = R,
   k = k,
-  percent_transmission = percent_transmission
+  prop_transmission = prop_transmission
 )
 
 # example with vectors of R and k
@@ -130,7 +131,7 @@ R <- c(1, 2, 3)
 proportion_transmission(
   R = R,
   k = k,
-  percent_transmission = percent_transmission
+  prop_transmission = prop_transmission
 )
 }
 \references{

--- a/tests/testthat/_snaps/proportion_transmission.md
+++ b/tests/testthat/_snaps/proportion_transmission.md
@@ -1,7 +1,7 @@
 # proportion_transmission works as expected for single R and k
 
     Code
-      proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.8)
+      proportion_transmission(R = 2, k = 0.5, prop_transmission = 0.8)
     Output
         R   k prop_80
       1 2 0.5   26.4%
@@ -9,7 +9,7 @@
 # proportion_transmission works as expected for multiple R
 
     Code
-      proportion_transmission(R = c(1, 2, 3), k = 0.5, percent_transmission = 0.8)
+      proportion_transmission(R = c(1, 2, 3), k = 0.5, prop_transmission = 0.8)
     Output
         R   k prop_80
       1 1 0.5   22.6%
@@ -20,7 +20,7 @@
 
     Code
       proportion_transmission(R = c(1, 2, 3), k = c(0.1, 0.2, 0.3),
-      percent_transmission = 0.8)
+      prop_transmission = 0.8)
     Output
         R   k prop_80
       1 1 0.1   8.69%
@@ -37,7 +37,7 @@
 
     Code
       proportion_transmission(R = c(1, 2, 3), k = c(0.1, 0.2, 0.3),
-      percent_transmission = 0.8, format_prop = FALSE)
+      prop_transmission = 0.8, format_prop = FALSE)
     Output
         R   k    prop_80
       1 1 0.1 0.08693433
@@ -53,7 +53,7 @@
 # proportion_transmission works as expected for Inf k
 
     Code
-      proportion_transmission(R = 2, k = Inf, percent_transmission = 0.8)
+      proportion_transmission(R = 2, k = Inf, prop_transmission = 0.8)
     Message
       Infinite values of k are being approximated by 1e+05 for calculations.
     Output
@@ -63,17 +63,17 @@
 # proportion_transmission works for k > 1e7 for method = t_20
 
     Code
-      proportion_transmission(R = 2, k = 1e+10, percent_transmission = 0.8, method = "t_20")
+      proportion_transmission(R = 2, k = 1e+10, prop_transmission = 0.8, method = "t_20")
     Message
       Values of `k` > 1e+07 are set to 1e+07 due to numerical integration issues at higher values.
     Output
         R     k prop_80
       1 2 1e+10   80.4%
 
-# proportion_transmission works for percent_transmission > 0.99
+# proportion_transmission works for prop_transmission > 0.99
 
     Code
-      proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.9999, method = "p_80")
+      proportion_transmission(R = 2, k = 0.5, prop_transmission = 0.9999, method = "p_80")
     Output
         R   k prop_99.99
       1 2 0.5      55.3%
@@ -81,9 +81,9 @@
 ---
 
     Code
-      proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.9999, method = "t_20")
+      proportion_transmission(R = 2, k = 0.5, prop_transmission = 0.9999, method = "t_20")
     Message
-      Values of `percent_transmission` > 0.99 are set to 0.99 due to numerical integration issues at higher values.
+      Values of `prop_transmission` > 0.99 are set to 0.99 due to numerical integration issues at higher values.
     Output
         R   k prop_99.99
       1 2 0.5       100%
@@ -99,14 +99,14 @@
 # .prop_transmission_analytical works as expected
 
     Code
-      .prop_transmission_analytical(R = 2, k = 0.5, percent_transmission = 0.8)
+      .prop_transmission_analytical(R = 2, k = 0.5, prop_transmission = 0.8)
     Output
       [1] 0.264419
 
 # proportion_transmission works with <epiparameter>
 
     Code
-      proportion_transmission(percent_transmission = 0.8, offspring_dist = od)
+      proportion_transmission(prop_transmission = 0.8, offspring_dist = od)
     Output
            R    k prop_80
       1 1.63 0.16     13%

--- a/tests/testthat/test-proportion_transmission.R
+++ b/tests/testthat/test-proportion_transmission.R
@@ -1,12 +1,12 @@
 test_that("proportion_transmission works as expected for single R and k", {
   expect_snapshot(
-    proportion_transmission(R = 2, k = 0.5, percent_transmission = 0.8)
+    proportion_transmission(R = 2, k = 0.5, prop_transmission = 0.8)
   )
 
   res <- proportion_transmission(
     R = 2,
     k = 0.5,
-    percent_transmission = 0.8,
+    prop_transmission = 0.8,
     simulate = TRUE
   )
 
@@ -23,14 +23,14 @@ test_that("proportion_transmission works as expected for multiple R", {
     proportion_transmission(
       R = c(1, 2, 3),
       k = 0.5,
-      percent_transmission = 0.8
+      prop_transmission = 0.8
     )
   )
 
   res <- proportion_transmission(
     R = c(1, 2, 3),
     k = 0.5,
-    percent_transmission = 0.8,
+    prop_transmission = 0.8,
     simulate = TRUE
   )
 
@@ -47,14 +47,14 @@ test_that("proportion_transmission works as expected for multiple R & k", {
     proportion_transmission(
       R = c(1, 2, 3),
       k = c(0.1, 0.2, 0.3),
-      percent_transmission = 0.8
+      prop_transmission = 0.8
     )
   )
 
   res <- proportion_transmission(
     R = c(1, 2, 3),
     k = c(0.1, 0.2, 0.3),
-    percent_transmission = 0.8,
+    prop_transmission = 0.8,
     simulate = TRUE
   )
 
@@ -71,7 +71,7 @@ test_that("proportion_transmission works as expected for format_prop = FALSE", {
     proportion_transmission(
       R = c(1, 2, 3),
       k = c(0.1, 0.2, 0.3),
-      percent_transmission = 0.8,
+      prop_transmission = 0.8,
       format_prop = FALSE
     )
   )
@@ -79,7 +79,7 @@ test_that("proportion_transmission works as expected for format_prop = FALSE", {
 
 test_that("proportion_transmission works as expected for Inf k", {
   expect_snapshot(
-    proportion_transmission(R = 2, k = Inf, percent_transmission = 0.8)
+    proportion_transmission(R = 2, k = Inf, prop_transmission = 0.8)
   )
 })
 
@@ -88,18 +88,18 @@ test_that("proportion_transmission works for k > 1e7 for method = t_20", {
     proportion_transmission(
       R = 2,
       k = 1e10,
-      percent_transmission = 0.8,
+      prop_transmission = 0.8,
       method = "t_20"
     )
   )
 })
 
-test_that("proportion_transmission works for percent_transmission > 0.99", {
+test_that("proportion_transmission works for prop_transmission > 0.99", {
   expect_snapshot(
     proportion_transmission(
       R = 2,
       k = 0.5,
-      percent_transmission = 0.9999,
+      prop_transmission = 0.9999,
       method = "p_80"
     )
   )
@@ -107,7 +107,7 @@ test_that("proportion_transmission works for percent_transmission > 0.99", {
     proportion_transmission(
       R = 2,
       k = 0.5,
-      percent_transmission = 0.9999,
+      prop_transmission = 0.9999,
       method = "t_20"
     )
   )
@@ -115,32 +115,32 @@ test_that("proportion_transmission works for percent_transmission > 0.99", {
 
 test_that("proportion_transmission fails as expected", {
   expect_error(
-    proportion_transmission(R = "1", k = 0.1, percent_transmission = 0.8),
+    proportion_transmission(R = "1", k = 0.1, prop_transmission = 0.8),
     regexp = "Assertion on 'R' failed"
   )
 
   expect_error(
-    proportion_transmission(R = 1, k = "0.1", percent_transmission = 0.8),
+    proportion_transmission(R = 1, k = "0.1", prop_transmission = 0.8),
     regexp = "Assertion on 'k' failed"
   )
 
   expect_error(
-    proportion_transmission(R = 1, k = 0.1, percent_transmission = "0.8"),
-    regexp = "Assertion on 'percent_transmission' failed"
+    proportion_transmission(R = 1, k = 0.1, prop_transmission = "0.8"),
+    regexp = "Assertion on 'prop_transmission' failed"
   )
 
   expect_error(
     proportion_transmission(
       R = 1,
       k = 0.1,
-      percent_transmission = 0.8,
+      prop_transmission = 0.8,
       simulate = 1
     ),
     regexp = "Assertion on 'simulate' failed"
   )
 
   expect_error(
-    proportion_transmission(R = 1, k = 0, percent_transmission = 0.8),
+    proportion_transmission(R = 1, k = 0, prop_transmission = 0.8),
     regexp = "k must be greater than zero."
   )
 
@@ -148,7 +148,7 @@ test_that("proportion_transmission fails as expected", {
     proportion_transmission(
       R = 1,
       k = 0.1,
-      percent_transmission = 0.8,
+      prop_transmission = 0.8,
       method = "t_20",
       simulate = TRUE
     ),
@@ -161,7 +161,7 @@ test_that(".prop_transmission_numerical works as expected", {
     .prop_transmission_numerical(
       R = 2,
       k = 0.5,
-      percent_transmission = 0.8
+      prop_transmission = 0.8
     ),
     style = "json2",
     tolerance = 0.05
@@ -173,7 +173,7 @@ test_that(".prop_transmission_analytical works as expected", {
     .prop_transmission_analytical(
       R = 2,
       k = 0.5,
-      percent_transmission = 0.8
+      prop_transmission = 0.8
     )
   )
 })
@@ -190,7 +190,7 @@ test_that("proportion_transmission works with <epiparameter>", {
   )
   expect_snapshot(
     proportion_transmission(
-      percent_transmission = 0.8,
+      prop_transmission = 0.8,
       offspring_dist = od
     )
   )
@@ -202,7 +202,7 @@ test_that("proportion_transmission works for t_20 method", {
   df <- proportion_transmission(
     R = 3,
     k = 1,
-    percent_transmission = 0.2,
+    prop_transmission = 0.2,
     method = "t_20",
     format_prop = FALSE
   )
@@ -211,7 +211,7 @@ test_that("proportion_transmission works for t_20 method", {
   df <- proportion_transmission(
     R = 2,
     k = 10e4,
-    percent_transmission = 0.2,
+    prop_transmission = 0.2,
     method = "t_20",
     format_prop = FALSE
   )
@@ -220,7 +220,7 @@ test_that("proportion_transmission works for t_20 method", {
 
 test_that("proportion_transmission fails without R and k or <epiparameter>", {
   expect_error(
-    proportion_transmission(percent_transmission = 0.8),
+    proportion_transmission(prop_transmission = 0.8),
     regexp = "Only one of `R` and `k` or `offspring_dist` must be supplied."
   )
 })

--- a/vignettes/proportion_transmission.Rmd
+++ b/vignettes/proportion_transmission.Rmd
@@ -35,9 +35,9 @@ The proportion of transmission can be calculated using two methods, both of whic
 ::: {.alert .alert-danger}
 The output of `method = "p_80"` and `method = "t_20"` have different interpretations and cannot be used interchangeably without understanding the differences in what they are measuring. 
 
-The output of `method = "p_80"` gives the proportion of cases that generate a certain proportion of realised transmission. The most common use case is calculating what proportion of cases would cause 80% of transmission during an outbreak of the infection. Thus a small proportion in the output `<data.frame>` means that there is a lot of overdispersion in individual-level transmission. The `percent_transmission` argument when `method = "p_80"` is to set the proportion of transmission.
+The output of `method = "p_80"` gives the proportion of cases that generate a certain proportion of realised transmission. The most common use case is calculating what proportion of cases would cause 80% of transmission during an outbreak of the infection. Thus a small proportion in the output `<data.frame>` means that there is a lot of overdispersion in individual-level transmission. The `prop_transmission` argument when `method = "p_80"` is to set the proportion of transmission.
 
-The output of `method = "t_20"` gives the proportion of cases that we would expected to produced by a certain proportion of the most infectious individuals. This is commonly used to calculate what proportion of cases are expected to be caused by the most infectious 20% of individuals. A high proportion in the output `<data.frame>` means that there is a lot of overdispersion in the transmission. The `percent_transmission` argument when `method = "t_20"` is to set the proportion of most infectious cases to calculate their proportion of total transmission.
+The output of `method = "t_20"` gives the proportion of cases that we would expected to produced by a certain proportion of the most infectious individuals. This is commonly used to calculate what proportion of cases are expected to be caused by the most infectious 20% of individuals. A high proportion in the output `<data.frame>` means that there is a lot of overdispersion in the transmission. The `prop_transmission` argument when `method = "t_20"` is to set the proportion of most infectious cases to calculate their proportion of total transmission.
 
 The key difference is that in a realised large outbreak (i.e. one that includes stochastic transmission), it is highly likely that some individuals will generate no secondary cases. This is because even a non-zero expected number of secondary cases can produce a zero when drawn from a Poisson process.
 :::
@@ -68,7 +68,7 @@ $$
 
 $f_\nu(x)$ is the probability density function (pdf) of the gamma distribution of the individual reproduction number $\nu$.
 
-For both methods the proportion of transmission can be modified using the `percent_transmission` argument in `proportion_transmission()` so they are not fixed at 80 and 20, respectively, for $p_{80}$ and $t_{20}$.
+For both methods the proportion of transmission can be modified using the `prop_transmission` argument in `proportion_transmission()` so they are not fixed at 80 and 20, respectively, for $p_{80}$ and $t_{20}$.
 
 There are two methods for calculating the $p_{80}$ method, analytically as given by @endoEstimatingOverdispersionCOVID192020, or numerically by sampling from a negative binomial distribution (`proportion_transmission(..., simulate = TRUE)`. For the purpose of this vignette to compare all of the methods we will term the analytical calculation $p_{80}$, and the numerical calculation $p_{80}^{sim}$.
 
@@ -122,7 +122,7 @@ offspring_dist_params$t20 <- do.call(
     MARGIN = 1,
     function(x) {
       proportion_transmission(
-        R = as.numeric(x[2]), k = as.numeric(x[3]), percent_transmission = 0.2,
+        R = as.numeric(x[2]), k = as.numeric(x[3]), prop_transmission = 0.2,
         method = "t_20", format_prop = FALSE
       )
     }
@@ -136,7 +136,7 @@ offspring_dist_params$p80 <- do.call(
     MARGIN = 1,
     function(x) {
       proportion_transmission(
-        R = as.numeric(x[2]), k = as.numeric(x[3]), percent_transmission = 0.8,
+        R = as.numeric(x[2]), k = as.numeric(x[3]), prop_transmission = 0.8,
         method = "p_80", format_prop = FALSE
       )
     }
@@ -241,7 +241,7 @@ y <- map_dbl(
   k_seq,
   function(x) {
     proportion_transmission(
-      R = 2, k = x, percent_transmission = 0.2,
+      R = 2, k = x, prop_transmission = 0.2,
       method = "t_20", format_prop = FALSE
     )[, 3]
   }
@@ -302,24 +302,24 @@ The plot uses an $R$ of 2, however, one characteristic of the $t_{20}$ method is
 ```{r}
 # For k = 0.5
 proportion_transmission(
-  R = 0.1, k = 0.5, percent_transmission = 0.8, method = "t_20"
+  R = 0.1, k = 0.5, prop_transmission = 0.8, method = "t_20"
 )
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.8, method = "t_20"
+  R = 1, k = 0.5, prop_transmission = 0.8, method = "t_20"
 )
 proportion_transmission(
-  R = 5, k = 0.5, percent_transmission = 0.8, method = "t_20"
+  R = 5, k = 0.5, prop_transmission = 0.8, method = "t_20"
 )
 
 # For k = 2
 proportion_transmission(
-  R = 0.1, k = 2, percent_transmission = 0.8, method = "t_20"
+  R = 0.1, k = 2, prop_transmission = 0.8, method = "t_20"
 )
 proportion_transmission(
-  R = 1, k = 2, percent_transmission = 0.8, method = "t_20"
+  R = 1, k = 2, prop_transmission = 0.8, method = "t_20"
 )
 proportion_transmission(
-  R = 5, k = 2, percent_transmission = 0.8, method = "t_20"
+  R = 5, k = 2, prop_transmission = 0.8, method = "t_20"
 )
 ```
 
@@ -328,46 +328,46 @@ This is not the case for $p_{80}$, where changes in both $R$ and $k$ influence t
 ```{r}
 # For k = 0.5
 proportion_transmission(
-  R = 0.1, k = 0.5, percent_transmission = 0.8, method = "p_80"
+  R = 0.1, k = 0.5, prop_transmission = 0.8, method = "p_80"
 )
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.8, method = "p_80"
+  R = 1, k = 0.5, prop_transmission = 0.8, method = "p_80"
 )
 proportion_transmission(
-  R = 5, k = 0.5, percent_transmission = 0.8, method = "p_80"
+  R = 5, k = 0.5, prop_transmission = 0.8, method = "p_80"
 )
 
 # For k = 2
 proportion_transmission(
-  R = 0.1, k = 2, percent_transmission = 0.8, method = "p_80"
+  R = 0.1, k = 2, prop_transmission = 0.8, method = "p_80"
 )
 proportion_transmission(
-  R = 1, k = 2, percent_transmission = 0.8, method = "p_80"
+  R = 1, k = 2, prop_transmission = 0.8, method = "p_80"
 )
 proportion_transmission(
-  R = 5, k = 2, percent_transmission = 0.8, method = "p_80"
+  R = 5, k = 2, prop_transmission = 0.8, method = "p_80"
 )
 ```
 
 One thing that was mentioned above is that the interpretation of the $p_{80}$ and $t_{20}$ methods are not interchangeable, additionally, $t_{80}$ and $p_{20}$ are not equal. Stated differently, the $p_{80}$ method to calculate the proportion of transmission that cause 20% of cases, and the $t_{20}$ method to calculate the proportion of transmission caused by the most infectious 80% are not equivalent. It is also the case that $1 - p_{80} \neq t_{20}$, thus $1 - t_{20} \neq p_{80}$.
 
-Here we vary $R$ and $k$ and show that by setting the $p_{80}$ method to `percent_transmission = 0.2`, and the $t_{20}$ method to `percent_transmission = 0.8` the two cannot be interchangeably interpreted as outlined in the box above.
+Here we vary $R$ and $k$ and show that by setting the $p_{80}$ method to `prop_transmission = 0.2`, and the $t_{20}$ method to `prop_transmission = 0.8` the two cannot be interchangeably interpreted as outlined in the box above.
 
 ```{r}
 # R = 1, k = 0.5
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.2, method = "p_80"
+  R = 1, k = 0.5, prop_transmission = 0.2, method = "p_80"
 )
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.8, method = "t_20"
+  R = 1, k = 0.5, prop_transmission = 0.8, method = "t_20"
 )
 
 # R = 3, k = 2
 proportion_transmission(
-  R = 3, k = 2, percent_transmission = 0.2, method = "p_80"
+  R = 3, k = 2, prop_transmission = 0.2, method = "p_80"
 )
 proportion_transmission(
-  R = 3, k = 2, percent_transmission = 0.8, method = "t_20"
+  R = 3, k = 2, prop_transmission = 0.8, method = "t_20"
 )
 ```
 
@@ -375,19 +375,19 @@ Here we show that $1 - p_{80} \neq t_{20}$ and $1 - t_{20} \neq p_{80}$.
 
 ```{r}
 1 - proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.8, method = "p_80",
+  R = 1, k = 0.5, prop_transmission = 0.8, method = "p_80",
   format_prop = FALSE
 )[, 3]
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.2, method = "t_20"
+  R = 1, k = 0.5, prop_transmission = 0.2, method = "t_20"
 )
 
 1 - proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.2, method = "t_20",
+  R = 1, k = 0.5, prop_transmission = 0.2, method = "t_20",
   format_prop = FALSE
 )[, 3]
 proportion_transmission(
-  R = 1, k = 0.5, percent_transmission = 0.8, method = "p_80"
+  R = 1, k = 0.5, prop_transmission = 0.8, method = "p_80"
 )
 ```
 
@@ -395,10 +395,10 @@ The $t_{20}$ method allows for true homogeneity when $k \rightarrow \infty$ ($t_
 
 ```{r}
 proportion_transmission(
-  R = 1, k = Inf, percent_transmission = 0.8, method = "p_80"
+  R = 1, k = Inf, prop_transmission = 0.8, method = "p_80"
 )
 proportion_transmission(
-  R = 1, k = Inf, percent_transmission = 0.8, method = "t_20"
+  R = 1, k = Inf, prop_transmission = 0.8, method = "t_20"
 )
 ```
 


### PR DESCRIPTION
This PR changes the name of the `percent_transmission` function argument to `prop_transmission()` in the `proportion_transmission()` function. The argument accepts a number between 0 and 1, and therefore describing it as a proportion instead of a percentage should be clearer to users and prevent users mistakenly supplying values between 1 and 100. 

This is a ***breaking change***.

The function documentation and `proportion_transmission.Rmd` vignette have been updated to use the new argument name, as have the unit tests and snapshot files. 