### PR TITLE
Add LSHTM as copyright holder 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,9 @@ Authors@R: c(
     person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = c("rev", "ctb"),
            comment = c(ORCID = "0000-0001-5782-7330")),
     person("Chris", "Hartgerink", , "chris@data.org", role = "rev",
-           comment = c(ORCID = "0000-0003-1050-6809"))
+           comment = c(ORCID = "0000-0003-1050-6809")),
+    person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
+           comment = c(ROR = "00a0jsq62"))
   )
 Description: Estimate and understand individual-level variation in
     transmission. Implements density and cumulative compound Poisson

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -52,6 +52,7 @@ infty
 init
 int
 integerish
+jsq
 KaTeX
 knitr
 Koella
@@ -67,6 +68,7 @@ Lim
 linetype
 lognormally
 Loucoubar
+LSHTM
 lw
 Magassouba
 Martín

--- a/man/superspreading-package.Rd
+++ b/man/superspreading-package.Rd
@@ -33,6 +33,7 @@ Other contributors:
   \item Hugo Gruson \email{hugo@data.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID}) [reviewer]
   \item James M. Azam \email{james.azam@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5782-7330}{ORCID}) [reviewer, contributor]
   \item Chris Hartgerink \email{chris@data.org} (\href{https://orcid.org/0000-0003-1050-6809}{ORCID}) [reviewer]
+  \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
 }
 
 }


### PR DESCRIPTION
This PR adds the London School of Hygiene and Tropical Medicine as a copyright holder (`cph`) to the `DESCRIPTION` and adds the LSHTM [ROR](https://ror.org/). 