### PR TITLE
Fix `update-citation-cff.yaml`

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -17,7 +17,6 @@ name: Update CITATION.cff
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   update-citation-cff:
@@ -58,3 +57,4 @@ jobs:
 
             Please verify the changes before merging.
           branch: update-citation-cff
+          add-paths: CITATION.cff

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - fix-update-citation-cff
     paths:
       - 'DESCRIPTION'
       - 'inst/CITATION'

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - fix-update-citation-cff
     paths:
       - 'DESCRIPTION'
       - 'inst/CITATION'

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -17,6 +17,7 @@ name: Update CITATION.cff
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   update-citation-cff:

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
     paths:
-      - DESCRIPTION
-      - inst/CITATION
-      - .github/workflows/update-citation-cff.yaml
+      - 'DESCRIPTION'
+      - 'inst/CITATION'
+      - '.github/workflows/update-citation-cff.yaml'
   workflow_dispatch:
 
 name: Update CITATION.cff

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,7 +58,7 @@ references:
     given-names: Michel
     email: michellang@gmail.com
     orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.checkmate
 - type: software
   title: rlang
@@ -73,7 +73,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.rlang
 - type: software
   title: stats
@@ -84,7 +84,7 @@ references:
   institution:
     name: R Foundation for Statistical Computing
     address: Vienna, Austria
-  year: '2025'
+  year: '2026'
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'
@@ -108,7 +108,7 @@ references:
     given-names: Davis
     email: davis@posit.co
     orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.dplyr
 - type: software
   title: epiparameter
@@ -130,7 +130,7 @@ references:
     given-names: Carmen
     email: carmen.tamayo-cuartero@lshtm.ac.uk
     orcid: https://orcid.org/0000-0003-4184-2864
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.epiparameter
   version: '>= 0.4.0'
 - type: software
@@ -153,7 +153,7 @@ references:
     given-names: Aurélie
     email: aurelie.siberchicot@univ-lyon1.fr
     orcid: https://orcid.org/0000-0002-7638-8318
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.fitdistrplus
 - type: software
   title: ggplot2
@@ -193,7 +193,7 @@ references:
     given-names: Teun
     name-particle: van den
     orcid: https://orcid.org/0000-0002-9335-7468
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.ggplot2
 - type: software
   title: ggtext
@@ -210,7 +210,7 @@ references:
     given-names: Brenton M.
     email: brenton@wiernik.org
     orcid: https://orcid.org/0000-0001-9560-6336
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.ggtext
 - type: software
   title: knitr
@@ -223,7 +223,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.knitr
 - type: software
   title: purrr
@@ -239,7 +239,7 @@ references:
   - family-names: Henry
     given-names: Lionel
     email: lionel@posit.co
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.purrr
 - type: software
   title: rmarkdown
@@ -283,7 +283,7 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.rmarkdown
 - type: software
   title: scales
@@ -301,7 +301,7 @@ references:
     orcid: https://orcid.org/0000-0002-5147-4711
   - family-names: Seidel
     given-names: Dana
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.scales
 - type: software
   title: spelling
@@ -317,7 +317,7 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.hester@rstudio.com
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.spelling
 - type: software
   title: testthat
@@ -329,7 +329,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2025'
+  year: '2026'
   doi: 10.32614/CRAN.package.testthat
   version: '>= 3.0.0'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -101,6 +101,7 @@ rfloor
 rightarrow
 rlang
 rmarkdown
+ROR
 Rustom
 Sánchez
 SAR

--- a/man/superspreading-package.Rd
+++ b/man/superspreading-package.Rd
@@ -33,7 +33,7 @@ Other contributors:
   \item Hugo Gruson \email{hugo@data.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID}) [reviewer]
   \item James M. Azam \email{james.azam@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5782-7330}{ORCID}) [reviewer, contributor]
   \item Chris Hartgerink \email{chris@data.org} (\href{https://orcid.org/0000-0003-1050-6809}{ORCID}) [reviewer]
-  \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
+  \item London School of Hygiene and Tropical Medicine, LSHTM (\href{https://ror.org/00a0jsq62}{ROR}) [copyright holder]
 }
 
 }


### PR DESCRIPTION
This PR fixes the `update-citation-cff.yaml` GitHub actions workflow by adding `add-paths: CITATION.cff` to the `.yaml` file. 

The GitHub actions error (which has only started recently) occurs in `peter-evans/create-pull-request@v8`:
```
/usr/bin/git push --force-with-lease origin update-citation-cff:refs/heads/update-citation-cff
  To https://github.com/epiverse-trace/superspreading
   ! [remote rejected] update-citation-cff -> update-citation-cff (refusing to allow a GitHub App to create or update workflow `.github/workflows/pkgdown.yaml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/epiverse-trace/superspreading'
  Error: The process '/usr/bin/git' failed with exit code 1
```

I'm unclear why the `update-citation-cff.yaml` is trying to edit the `pkgdown.yaml` file. Adding `add-paths: CITATION.cff` should avoid the changes to this file.